### PR TITLE
[FE-7] Style: tailwind theme 추가

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,48 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
-  theme: {
-    extend: {},
-  },
   plugins: [],
+  theme: {
+    extend: {
+      colors: {
+        'p-1': '#6026DA',
+        'p-2': '#703CDE',
+        'p-3': '#8052E1',
+        'p-4': '#9067E5',
+        'p-5': '#9F7DE9',
+        'p-6': '#AF93EC',
+        'p-7': '#BFA8F0',
+        'p-8': '#CFBEF4',
+        'p-9': '#DFD4F8',
+        'p-10': '#EFE9FB',
+
+        's-1': '#F33D63',
+        's-2': '#F45073',
+        's-3': '#F56482',
+        's-4': '#F77792',
+        's-5': '#F88BA1',
+        's-6': '#F99EB1',
+        's-7': '#FAB1C1',
+        's-8': '#FCC5D0',
+        's-9': '#FDD8E0',
+        's-10': '#FEECEF',
+
+        'g-1': '#FFFFFF',
+        'g-2': '#F1F1F1',
+        'g-3': '#E0E0E0',
+        'g-4': '#CECECE',
+        'g-5': '#B8B8B8',
+        'g-6': '#A0A0A0',
+        'g-7': '#7D7D7D',
+        'g-8': '#656565',
+        'g-9': '#3E3E3E',
+        'g-10': '#121212',
+
+        'i-purple': '#9067E5',
+        'i-yellow': '#F3D06C',
+        'i-pink': '#D78A86',
+        'i-blue': '#6F99F2',
+        'i-green': '#78BCB7',
+      },
+    },
+  },
 }


### PR DESCRIPTION
- theme colors 추가

## 작업 내용
- tailwind theme colors 추가 (적용되는 것 확인함, intelligence 플러그인 사용시 자동완성에도 뜸)
- fontFamaily도 추가해서 일괄 적용하려고 했으나 sf pro display 글꼴 저작권 이슈 발생할 것 같아 우선 보류함

## 참고 이미지(선택)
- 없음

## 어떤 점을 리뷰 받고 싶으신가요?
- 없음