### PR TITLE
[FE-22] prettier-plugin-tailwindcss 설치

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "eslint.alwaysShowStatus": true,
   "editor.codeActionsOnSave": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "postcss": "^8.4.20",
         "postcss-loader": "^7.0.2",
         "prettier": "^2.8.1",
+        "prettier-plugin-tailwindcss": "^0.2.1",
         "tailwindcss": "^3.2.4"
       }
     },
@@ -13922,6 +13923,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.1.tgz",
+      "integrity": "sha512-aIO8IguumORyRsmT+E7JfJ3A9FEoyhqZR7Au7TBOege3VZkgMvHJMkufeYp4zjnDK2iq4ktkvGMNOQR9T8lisQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -27069,6 +27082,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.1.tgz",
+      "integrity": "sha512-aIO8IguumORyRsmT+E7JfJ3A9FEoyhqZR7Au7TBOege3VZkgMvHJMkufeYp4zjnDK2iq4ktkvGMNOQR9T8lisQ==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "postcss": "^8.4.20",
     "postcss-loader": "^7.0.2",
     "prettier": "^2.8.1",
+    "prettier-plugin-tailwindcss": "^0.2.1",
     "tailwindcss": "^3.2.4"
   },
   "jira-prepare-commit-msg": {


### PR DESCRIPTION
## 작업 내용
 - prettier-plugin-tailwindcss 설치 / 셋팅
 - prettier 랑 연계되어 tailwind 클래스명을 자동정렬해주는 플러그인이라 에디터 기본 포매터를 프리티어로 설정
 - tailwind 권장 클래스 순서대로 정렬 (https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted) 

## 참고 이미지(선택)
 - 없음

## 어떤 점을 리뷰 받고 싶으신가요?
 - 없음