### PR TITLE
[FE-20] feat: 레이아웃 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,17 +4,20 @@ import { RecoilRoot } from 'recoil'
 
 import React from 'react'
 import Router from './routes/routes'
+import Layout from '@components/Layout'
 
 const queryClient = new QueryClient()
 
 function App() {
   return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <Router />
-        <ReactQueryDevtools />
-      </QueryClientProvider>
-    </RecoilRoot>
+    <Layout>
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <Router />
+          <ReactQueryDevtools />
+        </QueryClientProvider>
+      </RecoilRoot>
+    </Layout>
   )
 }
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen w-screen justify-center min-[450px]:bg-primary-9">
+      <div className="h-full w-[350px] max-w-[450px] bg-grey-1">{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 작업 내용
 - 레이아웃 추가
 - 실제로 쓸 컨테이너는 350px로 고정해서 화면이 450px 넘어가면 350px의 컨테이너 화면과 배경색으로 분리된 느낌 (450px 전까지는 흰색으로 padding 느낌으로 처리)
 - children 렌더링

## 참고 이미지(선택)
 - 449px 일때
<img width="455" alt="스크린샷 2022-12-21 오후 5 49 57" src="https://user-images.githubusercontent.com/88193063/208861214-3952a491-d4a4-4df6-b2a9-1be2874ca438.png">

 - 450px 일때
<img width="449" alt="스크린샷 2022-12-21 오후 5 50 08" src="https://user-images.githubusercontent.com/88193063/208861281-a830bd79-cf4c-4b08-8759-59539a99bbb0.png">


## 어떤 점을 리뷰 받고 싶으신가요?
 - 이정도로 충분할까요? 그리고 컨테이너를 350px로 고정해놓는 것이 맞을지 의견 부탁드립니다.