### PR TITLE
[FE-20] fix: 레이아웃 수정

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen w-screen justify-center min-[450px]:bg-primary-9">
-      <div className="h-full w-[350px] max-w-[450px] bg-grey-1">{children}</div>
+    <div className="flex h-screen w-screen justify-center web:bg-primary-9">
+      <div className="h-full max-w-[450px] bg-grey-1 web:w-[375px] basic:w-[375px] small:w-screen">
+        {children}
+      </div>
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,11 @@ module.exports = {
       spacing: {
         85: '335px',
       },
+      screens: {
+        web: { min: '450px' },
+        basic: { min: '375px', max: '450px' },
+        small: { max: '375px' },
+      },
     },
   },
 }


### PR DESCRIPTION
## 작업 내용
 - 레이아웃 적용 픽셀 수정
 - 375px 로 고정해놨던 레이아웃을 375보다 작아지는 경우 스크린의 크기에 따라 작아지도록 수정하였습니다.
 - 450px 이상인 경우 375px 고정, wrapper 컨테이너 배경색 있음
 - 450px ~ 375px 인 경우 375고정, wrapper 컨테이너 배경색 없음
 - 375px 이하인 경우 스크린 크기에 따라 width 변경  

## 참고 이미지(선택)
 - 없음

## 어떤 점을 리뷰 받고 싶으신가요?
 - 없음