### PR TITLE
[FE-30] chore: eslint no-console, index.css에 마진, 패딩 설정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,6 @@ module.exports = {
     indent: 'off',
     '@typescript-eslint/no-var-requires': 0,
     'react/self-closing-comp': 'warn', // 셀프 클로징 태그 가능하면 적용
+    'no-console': 'warn',
   },
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,4 +4,6 @@
 
 * {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }


### PR DESCRIPTION
## 작업 내용
- eslint `console.log`입력시 경고 표시
- 배포 시 콘솔로 데이터 유출 방지

```js
 rules: {
    'no-console': 'warn',
  },
```

- index.css에 margin, padding 0 적용

## 참고 이미지(선택)
아래와 같은 margin이 없도록 0으로 적용
<img width="340" alt="image" src="https://user-images.githubusercontent.com/50071076/209066465-1fb26057-b731-4bc4-9e87-040635fb22fd.png">

## 어떤 점을 리뷰 받고 싶으신가요?