### PR TITLE
[FE-41]feat: 컴포넌트 이관

### DIFF
--- a/src/components/MainCategoryTap.tsx
+++ b/src/components/MainCategoryTap.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import { TEXT_DETAILS } from '../assets/constant/constant'
+
+//이 컴포넌트를 호출할때는 위로와 축하로 나눠질 상황에서 실행될 함수들을 꼭 props로 전달해주셔야 합니다.
+type MainCategory = {
+  handleRecordCelebration: () => void
+  handleRecordConsolation: () => void
+}
+function MainCategoryTap({
+  handleRecordCelebration,
+  handleRecordConsolation,
+}: MainCategory) {
+  const { CELEBRATION, CONSOLATION } = TEXT_DETAILS
+  const [recordType, setRecordType] = useState<string>(CELEBRATION)
+
+  const typeConfig = {
+    active: 'text-primary-2 border-b-2 border-current pb-4',
+    inactive: 'text-gray-600',
+  }
+
+  const handleRecordTypeToCelebration = (): void => {
+    setRecordType(CELEBRATION)
+    handleRecordCelebration()
+  }
+
+  const handleRecordTypeToConsolation = (): void => {
+    setRecordType(CONSOLATION)
+    handleRecordConsolation()
+  }
+
+  return (
+    <div className="mt-6 flex justify-between border-b border-gray-300 px-10  text-lg font-semibold">
+      <div
+        className={`${
+          recordType === CELEBRATION ? typeConfig.active : typeConfig.inactive
+        }`}
+        onClick={handleRecordTypeToCelebration}
+      >
+        축하 레코드
+      </div>
+      <div
+        className={`${
+          recordType === CONSOLATION ? typeConfig.active : typeConfig.inactive
+        }`}
+        onClick={handleRecordTypeToConsolation}
+      >
+        위로 레코드
+      </div>
+    </div>
+  )
+}
+
+export default MainCategoryTap

--- a/src/components/MainCategoryTap.tsx
+++ b/src/components/MainCategoryTap.tsx
@@ -1,17 +1,12 @@
-import React from 'react'
+import React, { Dispatch, SetStateAction } from 'react'
 import { TEXT_DETAILS } from '@assets/constant/constant'
 
-//이 컴포넌트를 호출할때는 위로와 축하로 나눠질 상황에서 실행될 함수들을 꼭 props로 전달해주셔야 합니다.
+//이 컴포넌트를 호출할때는 위로와 축하로 나눠질 상황에서 실행될 setState을 props로 전달해야합니다.
 type MainCategory = {
-  onRecordCelebration: () => void
-  onRecordConsolation: () => void
+  onSetRecordType: Dispatch<SetStateAction<'celebration' | 'consolation'>>
   currentRecordType: string
 }
-function MainCategoryTap({
-  onRecordCelebration,
-  onRecordConsolation,
-  currentRecordType,
-}: MainCategory) {
+function MainCategoryTap({ onSetRecordType, currentRecordType }: MainCategory) {
   const { CELEBRATION, CONSOLATION } = TEXT_DETAILS
 
   const typeConfig = {
@@ -20,11 +15,11 @@ function MainCategoryTap({
   }
 
   const handleRecordTypeToCelebration = (): void => {
-    onRecordCelebration()
+    onSetRecordType(CELEBRATION)
   }
 
   const handleRecordTypeToConsolation = (): void => {
-    onRecordConsolation()
+    onSetRecordType(CONSOLATION)
   }
 
   return (

--- a/src/components/MainCategoryTap.tsx
+++ b/src/components/MainCategoryTap.tsx
@@ -1,17 +1,18 @@
-import React, { useState } from 'react'
-import { TEXT_DETAILS } from '../assets/constant/constant'
+import React from 'react'
+import { TEXT_DETAILS } from '@assets/constant/constant'
 
 //이 컴포넌트를 호출할때는 위로와 축하로 나눠질 상황에서 실행될 함수들을 꼭 props로 전달해주셔야 합니다.
 type MainCategory = {
-  handleRecordCelebration: () => void
-  handleRecordConsolation: () => void
+  onRecordCelebration: () => void
+  onRecordConsolation: () => void
+  currentRecordType: string
 }
 function MainCategoryTap({
-  handleRecordCelebration,
-  handleRecordConsolation,
+  onRecordCelebration,
+  onRecordConsolation,
+  currentRecordType,
 }: MainCategory) {
   const { CELEBRATION, CONSOLATION } = TEXT_DETAILS
-  const [recordType, setRecordType] = useState<string>(CELEBRATION)
 
   const typeConfig = {
     active: 'text-primary-2 border-b-2 border-current pb-4',
@@ -19,20 +20,20 @@ function MainCategoryTap({
   }
 
   const handleRecordTypeToCelebration = (): void => {
-    setRecordType(CELEBRATION)
-    handleRecordCelebration()
+    onRecordCelebration()
   }
 
   const handleRecordTypeToConsolation = (): void => {
-    setRecordType(CONSOLATION)
-    handleRecordConsolation()
+    onRecordConsolation()
   }
 
   return (
     <div className="mt-6 flex justify-between border-b border-gray-300 px-10  text-lg font-semibold">
       <div
         className={`${
-          recordType === CELEBRATION ? typeConfig.active : typeConfig.inactive
+          currentRecordType === CELEBRATION
+            ? typeConfig.active
+            : typeConfig.inactive
         }`}
         onClick={handleRecordTypeToCelebration}
       >
@@ -40,7 +41,9 @@ function MainCategoryTap({
       </div>
       <div
         className={`${
-          recordType === CONSOLATION ? typeConfig.active : typeConfig.inactive
+          currentRecordType === CONSOLATION
+            ? typeConfig.active
+            : typeConfig.inactive
         }`}
         onClick={handleRecordTypeToConsolation}
       >

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -7,6 +7,7 @@ import AddRecordColor from './AddRecordColor'
 import AddRecordFile from './AddRecordFile'
 import AddRecordTitle from './AddRecordTitle'
 import { TEXT_DETAILS } from '@assets/constant/constant'
+import MainCategoryTap from '../../components/MainCategoryTap'
 
 export type CheckAllType = {
   input: boolean
@@ -24,16 +25,11 @@ export default function AddRecord() {
     textArea: false,
   })
 
-  const typeConfig = {
-    active: 'text-primary-2 border-b-2 border-current pb-4',
-    inactive: 'text-gray-600',
-  }
-
-  const handleRecordTypeToCelebration = (): void => {
+  const handleRecordCelebration = (): void => {
     setRecordType(CELEBRATION)
   }
 
-  const handleRecordTypeToConsolation = (): void => {
+  const handleRecordConsolation = (): void => {
     setRecordType(CONSOLATION)
   }
 
@@ -44,26 +40,10 @@ export default function AddRecord() {
   return (
     <div className="mb-6 pt-16">
       <BackButton />
-      <div className="mt-6 flex justify-between border-b border-gray-300 px-10  text-lg font-semibold">
-        <div
-          className={`${
-            recordType === 'celebration'
-              ? typeConfig.active
-              : typeConfig.inactive
-          }`}
-          onClick={handleRecordTypeToCelebration}
-        >
-          축하 레코드
-        </div>
-        <div
-          className={`${
-            recordType === CONSOLATION ? typeConfig.active : typeConfig.inactive
-          }`}
-          onClick={handleRecordTypeToConsolation}
-        >
-          위로 레코드
-        </div>
-      </div>
+      <MainCategoryTap
+        handleRecordCelebration={handleRecordCelebration}
+        handleRecordConsolation={handleRecordConsolation}
+      />
       <form onSubmit={handleSubmitData}>
         <AddRecordCategory currentRecordType={recordType} />
         <AddRecordTitle title={'레코드 제목'} />

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -18,20 +18,14 @@ export default function AddRecord() {
   const { CELEBRATION, CONSOLATION } = TEXT_DETAILS
   const CELEBRATE = 'celebrate'
 
-  const [recordType, setRecordType] = useState<string>(CELEBRATION)
+  const [recordType, setRecordType] = useState<'celebration' | 'consolation'>(
+    CELEBRATION
+  )
   const [currentCategory, setCurrentCategory] = useState(CELEBRATE)
   const [checkAllFilled, setCheckAllFilled] = useState<CheckAllType>({
     input: false,
     textArea: false,
   })
-
-  const handleRecordCelebration = (): void => {
-    setRecordType(CELEBRATION)
-  }
-
-  const handleRecordConsolation = (): void => {
-    setRecordType(CONSOLATION)
-  }
 
   const handleSubmitData = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault()
@@ -42,8 +36,7 @@ export default function AddRecord() {
       <BackButton />
       <MainCategoryTap
         currentRecordType={recordType}
-        onRecordCelebration={handleRecordCelebration}
-        onRecordConsolation={handleRecordConsolation}
+        onSetRecordType={setRecordType}
       />
       <form onSubmit={handleSubmitData}>
         <AddRecordCategory currentRecordType={recordType} />

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -7,7 +7,7 @@ import AddRecordColor from './AddRecordColor'
 import AddRecordFile from './AddRecordFile'
 import AddRecordTitle from './AddRecordTitle'
 import { TEXT_DETAILS } from '@assets/constant/constant'
-import MainCategoryTap from '../../components/MainCategoryTap'
+import MainCategoryTap from '@components/MainCategoryTap'
 
 export type CheckAllType = {
   input: boolean
@@ -25,11 +25,11 @@ export default function AddRecord() {
     textArea: false,
   })
 
-  const handleRecordCelebration = (): void => {
+  const onRecordCelebration = (): void => {
     setRecordType(CELEBRATION)
   }
 
-  const handleRecordConsolation = (): void => {
+  const onRecordConsolation = (): void => {
     setRecordType(CONSOLATION)
   }
 
@@ -41,8 +41,9 @@ export default function AddRecord() {
     <div className="mb-6 pt-16">
       <BackButton />
       <MainCategoryTap
-        handleRecordCelebration={handleRecordCelebration}
-        handleRecordConsolation={handleRecordConsolation}
+        currentRecordType={recordType}
+        onRecordCelebration={onRecordCelebration}
+        onRecordConsolation={onRecordConsolation}
       />
       <form onSubmit={handleSubmitData}>
         <AddRecordCategory currentRecordType={recordType} />

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -25,11 +25,11 @@ export default function AddRecord() {
     textArea: false,
   })
 
-  const onRecordCelebration = (): void => {
+  const handleRecordCelebration = (): void => {
     setRecordType(CELEBRATION)
   }
 
-  const onRecordConsolation = (): void => {
+  const handleRecordConsolation = (): void => {
     setRecordType(CONSOLATION)
   }
 
@@ -42,8 +42,8 @@ export default function AddRecord() {
       <BackButton />
       <MainCategoryTap
         currentRecordType={recordType}
-        onRecordCelebration={onRecordCelebration}
-        onRecordConsolation={onRecordConsolation}
+        onRecordCelebration={handleRecordCelebration}
+        onRecordConsolation={handleRecordConsolation}
       />
       <form onSubmit={handleSubmitData}>
         <AddRecordCategory currentRecordType={recordType} />

--- a/src/pages/AddRecord/AddRecordInput.tsx
+++ b/src/pages/AddRecord/AddRecordInput.tsx
@@ -29,7 +29,7 @@ function AddRecordInput({
 
   return (
     <div
-      className={` mb-10 flex justify-between border-b transition-all duration-300   ${
+      className={` mb-10 flex justify-between border-b border-primary-2 transition-all duration-300 ${
         inputFocus ? 'border-primary-2' : 'border-gray-400'
       }`}
     >


### PR DESCRIPTION
-원래 현재위로 탭 코드가 AddRecord파일에 의존되있었는데 해당 코드를 컴포넌트로 이관

## 작업 내용
AddRecord에 현재 위로 탭 코드 나누는걸 컴포넌트로 이관했습니다.
해당 컴포넌트를 사용할떄는 아래 사진처럼 꼭 위로/축하로 바뀔시 생성되는 함수를 props로 전달해주셔야되여
## 참고 이미지(선택)
![image](https://user-images.githubusercontent.com/103626175/209265288-cb55d95f-5a2f-4ab3-92dd-993514a3bad2.png)

## 어떤 점을 리뷰 받고 싶으신가요?
자유롭게 리뷰주세요 중점사항은 없습니다.