### PR TITLE
[FE-34] feat: 회원가입(닉네임 설정 페이지)구현

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -28,7 +28,7 @@ export default function Button({
       case 'default':
         return active
           ? 'border border-solid border-primary-3 bg-grey-1 text-primary-3 hover:border-primary-1 hover:text-primary-1'
-          : 'border border-solid border-inactive text-inactive'
+          : 'border border-solid border-inactive text-inactive bg-grey-1'
       case 'danger':
         return active
           ? 'border border-solid border-grey-6 bg-grey-1 text-grey-6 hover:border-danger hover:text-danger'

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+interface InputPropsType extends React.InputHTMLAttributes<HTMLInputElement> {
+  property?: 'default'
+  name: string
+  label?: string
+  placeholder?: string
+  value?: number | string
+  message?: string
+  autoFocus?: boolean
+}
+
+export default function Input({
+  property = 'default',
+  name,
+  label,
+  placeholder,
+  value,
+  message,
+  autoFocus = true,
+  ...props
+}: InputPropsType) {
+  return (
+    <div>
+      <p className="pb-6">{label}</p>
+      <input
+        name={name}
+        value={value}
+        placeholder={placeholder}
+        className={`w-full border-b border-b-grey-4 pt-4 pb-4 placeholder:text-sm`}
+        autoFocus={autoFocus}
+        {...props}
+      />
+      <p className="pt-3 text-sm text-primary-2">{message}</p>
+    </div>
+  )
+}

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,0 +1,27 @@
+import Button from '@components/Button'
+import Input from '@components/Input'
+import React from 'react'
+
+export default function SignUp() {
+  return (
+    <div className="pl-6 pr-6">
+      <h1 className="6 mt-32 mb-32">
+        <span className="text-primary-2">레코딧</span>에서 어떤 닉네임을
+        <br />
+        사용하시겠어요?
+      </h1>
+      <Input
+        label="닉네임"
+        name="nickname"
+        placeholder="국문, 영문, 숫자 포함 3~8자"
+        message="사용가능한 닉네임이에요"
+      />
+      <div className="mt-[72px] flex flex-col items-center gap-2">
+        <Button active={false}>중복 확인</Button>
+        <Button property="solid" active={false}>
+          레코딧 입장
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -5,6 +5,7 @@ import DetailRecord from '@pages/DetailRecord/DetailRecord'
 import Main from '@pages/Main/Main'
 import NotFound from '@pages/NotFound/NotFound'
 import Login from '@pages/Login/Login'
+import SignUp from '@pages/SignUp/SignUp'
 
 export default function Router() {
   return (
@@ -14,7 +15,7 @@ export default function Router() {
         <Route path="/record/add" element={<AddRecord />} />
         <Route path="/record/:recordId" element={<DetailRecord />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/sign-up" element={<Login />} />
+        <Route path="/sign-up" element={<SignUp />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -11,9 +11,10 @@ export default function Router() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Main />} />
-        <Route path="/login" element={<Login />} />
         <Route path="/record/add" element={<AddRecord />} />
         <Route path="/record/:recordId" element={<DetailRecord />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/sign-up" element={<Login />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## 작업 내용
- 닉네임 설정 페이지 레이아웃 구현(기능X)
- 버튼 default 일 때 inactive 배경 색 추가
- input 컴포넌트를 임시로 만들었고 디자인 시스템 나오면 보완해서 만들겠습니다!

## 참고 이미지(선택)
![image](https://user-images.githubusercontent.com/50071076/209295294-a038aead-cf9b-4bee-ac87-09a58e04c7c0.png)

## 어떤 점을 리뷰 받고 싶으신가요?
`index.css`에 input 컴포넌트에 `border:none`이 설정되어 있는데 `border:inherit`으로 설정해도 괜찮을까요?

`border:none`이 설정되어있어서 border이 필요한 경우에 적용이 안됩니다!