### PR TITLE
[FE-48] 레이아웃 반응형 스크롤 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "postcss-loader": "^7.0.2",
         "prettier": "^2.8.1",
         "prettier-plugin-tailwindcss": "^0.2.1",
+        "tailwind-scrollbar": "^2.0.1",
         "tailwindcss": "^3.2.4"
       }
     },
@@ -15769,6 +15770,18 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "node_modules/tailwind-scrollbar": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-2.0.1.tgz",
+      "integrity": "sha512-OcR7qHBbux4k+k6bWqnEQFYFooLK/F4dhkBz6nvswIoaA9ancZ5h20e0tyV7ifSWLDCUBtpG+1NHRA8HMRH/wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "3.x"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
@@ -28452,6 +28465,13 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tailwind-scrollbar": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-2.0.1.tgz",
+      "integrity": "sha512-OcR7qHBbux4k+k6bWqnEQFYFooLK/F4dhkBz6nvswIoaA9ancZ5h20e0tyV7ifSWLDCUBtpG+1NHRA8HMRH/wg==",
+      "dev": true,
+      "requires": {}
     },
     "tailwindcss": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "postcss-loader": "^7.0.2",
     "prettier": "^2.8.1",
     "prettier-plugin-tailwindcss": "^0.2.1",
+    "tailwind-scrollbar": "^2.0.1",
     "tailwindcss": "^3.2.4"
   },
   "jira-prepare-commit-msg": {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen w-screen justify-center web:bg-primary-9">
-      <div className="h-full max-w-[450px] bg-grey-1 web:w-[375px] basic:w-[375px] small:w-screen">
+      <div className="h-full max-w-[450px] bg-grey-1 scrollbar-thin hover:scrollbar-track-grey-2 hover:scrollbar-thumb-primary-6 active:scrollbar-track-grey-2 active:scrollbar-thumb-primary-6 web:w-[375px] basic:w-[375px] small:w-screen">
         {children}
       </div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
   corePlugins: {
     preflight: false,
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar')({ nocompatible: true })],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## 작업 내용
- 레이아웃 반응형에 따른 스크롤 추가
- [tailwind-scrollbar](https://github.com/adoxography/tailwind-scrollbar) 플러그인 추가 설치
- 스크롤바 색상을 Primary 계열 색상으로 설정
- hover, active 시에만 스크롤 보이게 설정

## 참고 이미지(선택)
 - 호버 아닐때
<img width="515" alt="스크린샷 2022-12-25 오후 2 48 28" src="https://user-images.githubusercontent.com/88193063/209458278-02be538d-b629-432f-b6e3-3be8a2564fdc.png">

 - 호버 일 때
<img width="568" alt="스크린샷 2022-12-25 오후 2 48 41" src="https://user-images.githubusercontent.com/88193063/209458280-ac8f07e0-9711-4a10-afc8-c4bae3fa4cb7.png">


## 어떤 점을 리뷰 받고 싶으신가요?
- 스크롤 디자인이나 어떨때 visible 할 것인지에 대한 의견을 듣고 싶습니다.