### PR TITLE
[FE-40] feat: 레코드 상세 페이지 레이아웃 구성

### DIFF
--- a/src/assets/more.svg
+++ b/src/assets/more.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_847_4584)">
+<path d="M12 8C13.1 8 14 7.1 14 6C14 4.9 13.1 4 12 4C10.9 4 10 4.9 10 6C10 7.1 10.9 8 12 8ZM12 10C10.9 10 10 10.9 10 12C10 13.1 10.9 14 12 14C13.1 14 14 13.1 14 12C14 10.9 13.1 10 12 10ZM12 16C10.9 16 10 16.9 10 18C10 19.1 10.9 20 12 20C13.1 20 14 19.1 14 18C14 16.9 13.1 16 12 16Z" fill="#121212"/>
+</g>
+<defs>
+<clipPath id="clip0_847_4584">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/MoreButton.tsx
+++ b/src/components/MoreButton.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { ReactComponent as More } from '@assets/more.svg'
+
+export default function MoreButton() {
+  return <More>MoreButton</More>
+}

--- a/src/index.css
+++ b/src/index.css
@@ -99,6 +99,7 @@ video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
+  text-decoration: none;
 }
 
 /* HTML5 display-role reset for older browsers */

--- a/src/pages/DetailRecord/DetailRecord.tsx
+++ b/src/pages/DetailRecord/DetailRecord.tsx
@@ -1,5 +1,15 @@
+import BackButton from '@components/BackButton'
+import MoreButton from '@components/MoreButton'
 import React from 'react'
 
 export default function DetailRecord() {
-  return <div>DetailRecord</div>
+  return (
+    <div>
+      <header className="h-[60px]" />
+      <nav className="flex justify-between px-6">
+        <BackButton />
+        <MoreButton />
+      </nav>
+    </div>
+  )
 }

--- a/src/pages/DetailRecord/DetailRecord.tsx
+++ b/src/pages/DetailRecord/DetailRecord.tsx
@@ -1,15 +1,63 @@
 import BackButton from '@components/BackButton'
+import Button from '@components/Button'
+import Chip from '@components/Chip'
 import MoreButton from '@components/MoreButton'
 import React from 'react'
 
 export default function DetailRecord() {
   return (
-    <div>
+    <div className="w-full">
       <header className="h-[60px]" />
       <nav className="flex justify-between px-6">
         <BackButton />
         <MoreButton />
       </nav>
+      <section id="title" className="mt-7 flex flex-col px-6">
+        <div className="flex justify-between">
+          <p className="flex items-center text-2xl font-semibold">
+            제목은 최대 10자
+          </p>
+          <Chip active={true} icon={null} message={'축하해주세요'}></Chip>
+        </div>
+        <div className="mt-4 flex">
+          <p className="text-[14px]">닉네임</p>
+          <p className="px-4 text-xs text-grey-5">2022.12.01 12:00</p>
+        </div>
+      </section>
+      <section
+        id="record_context"
+        className="flex w-full flex-col items-center"
+      >
+        <div className="my-4 h-[338px] w-[338px] rounded-2xl bg-primary-3"></div>
+        <Button>공유하기</Button>
+        <div className="my-6 w-[327px] text-[14px]">
+          <p>레코드 내용은 200자까지 보이도록 합니다.</p>
+          <p>레코드 내용은 200자까지 보이도록 합니다.</p>
+        </div>
+      </section>
+      <section id="reply" className="px-6">
+        <p>댓글</p>
+        <div className="mt-1.5">
+          <div className="rounded-lg bg-grey-2 p-3">
+            <div className="flex">
+              <p className="text-xs font-medium">익명</p>
+              <p className="mx-1.5 text-xs font-normal text-grey-5">0시간 전</p>
+            </div>
+            <p className="mt-1.5 text-xs font-normal text-grey-8">
+              댓글이 노출됩니다.
+            </p>
+          </div>
+          <div className="flex justify-end">
+            <button className="cursor-pointer bg-grey-1 text-xs text-[#F83636]">
+              신고
+            </button>
+            <button className="cursor-pointer bg-grey-1 text-xs text-grey-5">
+              수정
+            </button>
+          </div>
+        </div>
+      </section>
+      <footer></footer>
     </div>
   )
 }


### PR DESCRIPTION
## 작업 내용
- 레코드 상세 페이지 레이아웃
- 기본 골격만 잡고 추후 컴포넌트 분리 및 데이터 변수 생성 예정

## 참고 이미지(선택)
<img width="386" alt="스크린샷 2022-12-28 오후 4 41 42" src="https://user-images.githubusercontent.com/88193063/209777113-3b9ad293-f617-4ecb-ab1c-54184415e2a7.png">


## 어떤 점을 리뷰 받고 싶으신가요?
- 없음