### PR TITLE
[FE-70] fix: 닉네임 중복 구현 버그 픽스

### DIFF
--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -26,17 +26,14 @@ export default function SignUp() {
       const nicknamePattern = /[가-힣aA-z0-9]{2,8}/
 
       if (!nickname.match(nicknamePattern)) {
-        setIsCheckedNickname(false)
         error.nickname = '이미 사용중이거나 사용할 수 없는 닉네임입니다.'
       }
 
       if (nickname.match(spacePattern)) {
-        setIsCheckedNickname(false)
         error.nickname = '공백을 제거해주세요'
       }
 
       if (!isDuplicate) {
-        setIsCheckedNickname(false)
         error.nickname = '이미 사용중이거나 사용할 수 없는 닉네임입니다.'
       }
 
@@ -46,9 +43,9 @@ export default function SignUp() {
   const { isDuplicate } = useGetDuplicateNickname(values.nickname)
 
   useEffect(() => {
-    // if (!location.state?.tempSessionId) {
-    //   navigate('/login')
-    // }
+    if (!location.state?.tempSessionId) {
+      navigate('/login')
+    }
   }, [])
 
   const setPropertyWithisCheckedNickname = () => {

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -48,7 +48,7 @@ export default function SignUp() {
     }
   }, [])
 
-  const setPropertyWithisCheckedNickname = () => {
+  const setPropertyWithIsCheckedNickname = () => {
     if (isCheckedNickname) return 'success'
     if (errors.nickname as string) return 'error'
     return 'default'
@@ -80,7 +80,7 @@ export default function SignUp() {
       </h1>
       <form onSubmit={handleSubmit}>
         <Input
-          property={setPropertyWithisCheckedNickname()}
+          property={setPropertyWithIsCheckedNickname()}
           name="nickname"
           label="닉네임"
           value={values.nickname}

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -10,21 +10,15 @@ import { useGetDuplicateNickname } from '@react-query/hooks/useNickname'
 export default function SignUp() {
   const location = useLocation()
   const [isCheckedNickname, setIsCheckedNickname] = useState(false)
+  const [nickname, setNickname] = useState('')
   const { oauthSignUp } = useAuth()
   const navigate = useNavigate()
 
   const { values, errors, handleRemove, handleChange, handleSubmit } = useForm({
     initialValues: { nickname: '' },
     onSubmit: ({ nickname }) => {
-      if (!isCheckedNickname) {
-        if (isSuccess && isDuplicate) {
-          setIsCheckedNickname(true)
-        }
-        return
-      }
-
-      const { tempSessionId, loginType } = location.state
-      oauthSignUp({ type: loginType, tempId: tempSessionId, nickname })
+      setIsCheckedNickname(true)
+      setNickname(nickname)
     },
     validate: ({ nickname }) => {
       const error: { nickname?: string } = {}
@@ -32,21 +26,24 @@ export default function SignUp() {
       const nicknamePattern = /[가-힣aA-z0-9]{2,8}/
 
       if (!nickname.match(nicknamePattern)) {
+        setIsCheckedNickname(false)
         error.nickname = '이미 사용중이거나 사용할 수 없는 닉네임입니다.'
       }
 
       if (nickname.match(spacePattern)) {
+        setIsCheckedNickname(false)
         error.nickname = '공백을 제거해주세요'
       }
 
       if (!isDuplicate) {
+        setIsCheckedNickname(false)
         error.nickname = '이미 사용중이거나 사용할 수 없는 닉네임입니다.'
       }
 
       return error
     },
   })
-  const { isDuplicate, isSuccess } = useGetDuplicateNickname(values.nickname)
+  const { isDuplicate } = useGetDuplicateNickname(values.nickname)
 
   useEffect(() => {
     if (!location.state?.tempSessionId) {
@@ -64,6 +61,11 @@ export default function SignUp() {
     if (isRemove && !isCheckedNickname) {
       handleRemove('nickname')
     }
+  }
+
+  const handleSignUp = () => {
+    const { tempSessionId, loginType } = location.state
+    oauthSignUp({ type: loginType, tempId: tempSessionId, nickname })
   }
 
   return (
@@ -90,18 +92,22 @@ export default function SignUp() {
           onChange={handleChange}
           onRemove={handleRemoveNickname}
         />
-        <div className="mt-[72px] flex flex-col items-center gap-2">
-          <Button
-            type="submit"
-            active={!isCheckedNickname && values.nickname.length > 0}
-          >
+        <div className="mt-[72px]">
+          <Button type="submit" active={values.nickname.length > 0}>
             중복 확인
-          </Button>
-          <Button type="submit" property="solid" active={isCheckedNickname}>
-            레코딧 입장
           </Button>
         </div>
       </form>
+      <div className="mt-2">
+        <Button
+          type="submit"
+          property="solid"
+          active={isCheckedNickname}
+          onClick={handleSignUp}
+        >
+          레코딧 입장
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ChangeEvent } from 'react'
 import { useState, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import Button from '@components/Button'
@@ -46,9 +46,9 @@ export default function SignUp() {
   const { isDuplicate } = useGetDuplicateNickname(values.nickname)
 
   useEffect(() => {
-    if (!location.state?.tempSessionId) {
-      navigate('/login')
-    }
+    // if (!location.state?.tempSessionId) {
+    //   navigate('/login')
+    // }
   }, [])
 
   const setPropertyWithisCheckedNickname = () => {
@@ -61,6 +61,11 @@ export default function SignUp() {
     if (isRemove && !isCheckedNickname) {
       handleRemove('nickname')
     }
+  }
+
+  const handleChangeNickname = (e: ChangeEvent<HTMLInputElement>) => {
+    handleChange(e)
+    setIsCheckedNickname(false)
   }
 
   const handleSignUp = () => {
@@ -89,7 +94,7 @@ export default function SignUp() {
               ? '사용가능한 닉네임입니다.'
               : (errors.nickname as string)
           }
-          onChange={handleChange}
+          onChange={handleChangeNickname}
           onRemove={handleRemoveNickname}
         />
         <div className="mt-[72px]">

--- a/src/react-query/hooks/useNickname.ts
+++ b/src/react-query/hooks/useNickname.ts
@@ -3,10 +3,10 @@ import { QUERY_KEYS } from '@react-query/queryKeys'
 import { useQuery } from '@tanstack/react-query'
 
 export const useGetDuplicateNickname = (nickname: string) => {
-  const { data, isSuccess } = useQuery(
+  const { data } = useQuery(
     [QUERY_KEYS.nickname, nickname],
     async () => await getIsDuplicatedNickname(nickname)
   )
 
-  return { isDuplicate: data?.data, isSuccess }
+  return { isDuplicate: data?.data }
 }


### PR DESCRIPTION
- 닉네임과 회원가입 로직 분리

## 작업 내용
- 현재 닉네임 중복 기능에 적용되어 있던 useForm훅이 회원가입 로직도 연결되어 있어서 안되었었음
- 따라서 회원가입은 따로 함수로 빼서 적용시키고 닉네임 중복 구현만 useForm 훅을 사용하도록 변경하였습니다!!

## 참고 이미지(선택)

## 어떤 점을 리뷰 받고 싶으신가요?
없습니당