### PR TITLE
[FE-86] fix: 카카오/구글 버튼 아이폰에서만 파란색으로 보이는 버그 픽스

### DIFF
--- a/src/pages/Login/GoogleButton.tsx
+++ b/src/pages/Login/GoogleButton.tsx
@@ -16,11 +16,11 @@ export default function GoogleButton() {
   return (
     <button
       aria-label="google-login-button"
-      className="flex h-12 w-85 items-center rounded-xl border-none bg-grey-1 px-8 font-semibold hover:cursor-pointer"
+      className="flex h-12 w-85 items-center rounded-xl border-none bg-grey-1 px-8 font-semibold text-grey-10 hover:cursor-pointer"
       onClick={handleGoogleLogin}
     >
       <GoogleSymbol aria-label="google-symbol-icon" />
-      <p className="w-full text-kakao-label">Google로 계속하기</p>
+      <p className="w-full text-grey-10">Google로 계속하기</p>
     </button>
   )
 }

--- a/src/pages/Login/KakaoButton.tsx
+++ b/src/pages/Login/KakaoButton.tsx
@@ -16,11 +16,11 @@ export default function KakaoButton() {
   return (
     <button
       aria-label="kakao-login-button"
-      className="flex h-12 w-85 items-center rounded-xl border-none bg-kakao px-8 font-semibold hover:cursor-pointer"
+      className="flex h-12 w-85 items-center rounded-xl border-none bg-kakao px-8 font-semibold text-grey-10 hover:cursor-pointer"
       onClick={handleKakaoLogin}
     >
       <KakaoSymbol aria-label="kakao-symbol-icon" />
-      <p className="w-full text-kakao-label">카카오로 계속하기</p>
+      <p className="w-full text-grey-10">카카오로 계속하기</p>
     </button>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,7 +50,6 @@ module.exports = {
         inactive: '#D0D0D0',
 
         kakao: '#FEE500',
-        'kakao-label': '#000000 85%',
       },
       fontFamily: {
         sans: ['San Francisco'],


### PR DESCRIPTION
## 작업 내용
-  카카오/구글 버튼 아이폰에서만 파란색으로 보이는 버그 픽스

## 참고 이미지(선택)
- 아이폰에서만 아래처럼 파란색으로 보여서 이 부분 픽스해서 올립니다
![image](https://user-images.githubusercontent.com/50071076/211202655-c3b412a3-9499-4956-80e2-e9c02d53769a.png)

## 어떤 점을 리뷰 받고 싶으신가요?
없습니다