### PR TITLE
[FE-111]bug: 레코드 파일추가 안했을때 추가 안되는 버그 수정

### DIFF
--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -73,8 +73,9 @@ export default function AddRecord() {
     }
 
     const data = new FormData()
-
-    data.append('files', files as Blob, files?.name)
+    if (files !== undefined) {
+      data.append('files', files as File, files?.name)
+    }
     data.append(
       'writeRecordRequestDto',
       new Blob([JSON.stringify(formData)], { type: 'application/json' })


### PR DESCRIPTION
## 작업 내용
-formData에 파일에 undefined가 추가되면 파일 추가가 안되는 버그 수정
## 참고 이미지(선택)
![화면 기록 2023-01-15 오전 12 37 03](https://user-images.githubusercontent.com/103626175/212480145-d715b9eb-7d58-44c1-8ef3-23bcf398e36c.gif)

## 어떤 점을 리뷰 받고 싶으신가요?