### PR TITLE
[FE-119] feat: 레코드 추가하기 버튼에 로딩 추가

### DIFF
--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -59,10 +59,12 @@ export default function AddRecord() {
     const enroll = async () => {
       const response = await enrollRecord(formData)
       setFiles(undefined)
-      setIsLoadingWhileSubmit(true)
-      navigate(`/record/${response.data.recordId}`)
+      navigate(`/record/${response.data.recordId}`, {
+        replace: true,
+      })
     }
     enroll()
+    setIsLoadingWhileSubmit(true)
   }
 
   const makeFormDatas = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -47,6 +47,7 @@ export default function AddRecord() {
   const [files, setFiles] = useState<File>()
   const navigate = useNavigate()
   const [isClickBackButton, setIsBackButton] = useState(false)
+  const [isLoadingWhileSubmit, setIsLoadingWhileSubmit] = useState(false)
 
   useEffect(() => {
     setCheckAllFilled({ input: false, textArea: false })
@@ -58,6 +59,7 @@ export default function AddRecord() {
     const enroll = async () => {
       const response = await enrollRecord(formData)
       setFiles(undefined)
+      setIsLoadingWhileSubmit(true)
       navigate(`/record/${response.data.recordId}`)
     }
     enroll()
@@ -128,6 +130,7 @@ export default function AddRecord() {
             active={
               checkAllFilled.input && checkAllFilled.textArea ? true : false
             }
+            loading={isLoadingWhileSubmit}
           >
             레코드 추가하기
           </Button>


### PR DESCRIPTION
## 작업 내용
- 레코드 추가하기 버튼에 로딩 추가
- 레코드 추가한 후 replace적용으로 뒤로가기 안되도록 구현

## 참고 이미지(선택)
![로딩](https://user-images.githubusercontent.com/50071076/212546985-dc3478c2-247e-49d7-8e68-d621d964e093.gif)

## 어떤 점을 리뷰 받고 싶으신가요?
없습니다