### PR TITLE
[FE-130] fix : 레코드 상세 페이지 QA 에러 수정

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -19,7 +19,3 @@ export const getIsDuplicatedNickname = (nickname: string) => {
     params: { nickname },
   })
 }
-
-export const getNickname = () => {
-  return baseInstance.get('/member/auth')
-}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -41,8 +41,10 @@ export default function Button({
       case 'danger':
         return active
           ? `border border-solid bg-grey-1 ${
-              normal ? 'border-grey-6 text-grey-6' : 'border-danger text-danger'
-            } hover:border-danger hover:text-danger`
+              normal
+                ? 'border-grey-6 text-grey-6 hover:border-grey-7'
+                : 'border-danger text-danger hover:border-danger'
+            }`
           : 'border border-solid border-inactive text-inactive'
       default:
         return ''

--- a/src/pages/DetailRecord/DetailRecord.tsx
+++ b/src/pages/DetailRecord/DetailRecord.tsx
@@ -23,6 +23,7 @@ import { useQuery } from '@tanstack/react-query'
 import Loading from '@components/Loading'
 import { getChipIconName } from './getChipIconName'
 import ImageContainer from './ImageContainer'
+import { useUser } from '@react-query/hooks/useUser'
 
 export default function DetailRecord() {
   const [shareStatus, setShareStatus] = useState(false)
@@ -43,6 +44,8 @@ export default function DetailRecord() {
     createdAt,
     imageUrls,
   } = recordData
+
+  const { user } = useUser()
 
   const background_color = `bg-${colorName}`
 
@@ -112,12 +115,14 @@ export default function DetailRecord() {
         <header className="p-4">
           <nav className="flex justify-between">
             <BackButton />
-            <button
-              className="cursor-pointer bg-grey-1"
-              onClick={() => setEditModalState(true)}
-            >
-              <MoreButton />
-            </button>
+            {user?.data === writer && (
+              <button
+                className="cursor-pointer bg-grey-1"
+                onClick={() => setEditModalState(true)}
+              >
+                <MoreButton />
+              </button>
+            )}
           </nav>
         </header>
         <div className="mb-3 overflow-auto" ref={scrollSection}>
@@ -150,8 +155,8 @@ export default function DetailRecord() {
             <Button onClick={() => setShareStatus(true)}>
               <p className="text-base font-semibold">공유하기</p>
             </Button>
-            <div className="mt-6 mb-10 w-full px-1.5 text-[14px]">
-              <p className="w-full ">{content}</p>
+            <div className="mt-6 mb-10 w-full px-1.5 text-[14px] leading-normal">
+              <p className="w-full">{content}</p>
             </div>
           </section>
           <section id="record_reply_list">
@@ -160,7 +165,7 @@ export default function DetailRecord() {
         </div>
         <section
           id="record_reply_input"
-          className="absolute bottom-0 w-full border-t border-solid border-t-grey-2 bg-grey-1 px-6 py-4 "
+          className="absolute bottom-0 w-full border-t border-solid border-t-grey-2 bg-grey-1 py-4 pl-4 pr-6 "
         >
           <ReplyInput
             setInputSectionHeight={setInputSectionHeight}

--- a/src/pages/DetailRecord/ImageContainer.tsx
+++ b/src/pages/DetailRecord/ImageContainer.tsx
@@ -45,7 +45,7 @@ export default function ImageContainer({
       {imageState !== 0 && (
         <img
           src={imageUrls[imageState - 1]}
-          className="h-full w-full rounded-2xl object-cover"
+          className="aspect-square h-full w-full rounded-2xl object-cover"
         />
       )}
     </div>

--- a/src/pages/DetailRecord/ReplyInput.tsx
+++ b/src/pages/DetailRecord/ReplyInput.tsx
@@ -79,6 +79,7 @@ export default function ReplyInput({
     e.preventDefault()
 
     setText('')
+    setImage('')
     const writeCommentRequestDto = {
       recordId: recordId,
       comment: text,
@@ -121,41 +122,8 @@ export default function ReplyInput({
       encType="multipart/form-data"
       onSubmit={handleSubmitReplyData}
     >
-      <div className="w-[90%] rounded-lg bg-grey-2 py-4 px-3">
-        {image !== '' && (
-          <div className="relative mb-2.5 aspect-square w-[60px] rounded-2xl">
-            <img
-              className=" h-full w-full rounded-2xl"
-              src={image}
-              alt="user-selected-record-image"
-            />
-            <Close
-              className="absolute top-1.5 right-1.5 cursor-pointer"
-              onClick={handleDeleteImageFile}
-            />
-          </div>
-        )}
-        <div className="flex items-end">
-          <textarea
-            ref={textRef}
-            rows={1}
-            maxLength={100}
-            required={true}
-            placeholder="따뜻한 마음을 남겨주세요"
-            onInput={handleResizeHeight}
-            onChange={(e) => setText(e.target.value)}
-            value={text}
-            className="h-auto w-[85%] resize-none bg-inherit text-[14px] placeholder:text-grey-5 focus:outline-0"
-            onFocus={handleInputFocus}
-            disabled={isLoading}
-          />
-          <button className="cursor-pointer text-[12px] text-primary-2">
-            확인
-          </button>
-        </div>
-      </div>
       <label htmlFor="imageFile">
-        <div className="relative ml-2 mb-2 h-9 w-9 cursor-pointer bg-grey-1">
+        <div className="relative mr-2.5 mb-2 h-9 w-9 cursor-pointer bg-grey-1">
           <Camera className="absolute top-[7px] right-[5px]" />
           {image === '' && <Plus className="absolute right-0.5 top-[5px]" />}
         </div>
@@ -167,6 +135,46 @@ export default function ReplyInput({
           className="hidden"
         />
       </label>
+      <div className="w-[90%] rounded-lg bg-grey-2 py-4 px-3">
+        {image !== '' && (
+          <div className="relative mb-2.5 aspect-square w-[60px] rounded-2xl">
+            <img
+              className="aspect-square w-full rounded-2xl object-cover"
+              src={image}
+              alt="user-selected-record-image"
+            />
+            <Close
+              className="absolute top-1.5 right-1.5 cursor-pointer"
+              onClick={handleDeleteImageFile}
+            />
+          </div>
+        )}
+
+        <div className="flex items-end">
+          <textarea
+            ref={textRef}
+            rows={1}
+            maxLength={100}
+            required={true}
+            placeholder="따뜻한 마음을 남겨주세요. (100자 이내)"
+            onInput={handleResizeHeight}
+            onChange={(e) => setText(e.target.value)}
+            value={text}
+            className="h-auto w-[85%] resize-none bg-inherit text-[14px] placeholder:text-grey-5 focus:outline-0"
+            onFocus={handleInputFocus}
+            disabled={isLoading}
+          />
+          <button
+            disabled={text === ''}
+            className={`cursor-pointer text-[12px] ${
+              text !== '' ? 'text-primary-2' : 'text-grey-6'
+            }`}
+          >
+            완료
+          </button>
+        </div>
+      </div>
+
       {isCheckedUser && (
         <Alert
           visible={isCheckedUser && !isAnonymousUser}

--- a/src/pages/DetailRecord/ReplyItem.tsx
+++ b/src/pages/DetailRecord/ReplyItem.tsx
@@ -1,4 +1,4 @@
-import { getNickname } from '@apis/auth'
+import { useUser } from '@react-query/hooks/useUser'
 import React, { useEffect, useState } from 'react'
 import { CommentData } from 'types/replyData'
 import { getCreatedDate } from './getCreatedDate'
@@ -12,29 +12,22 @@ export default function ReplyItem({
   // numOfSubComment,
   writer,
 }: CommentData) {
-  const [nickName, setNickName] = useState<string | null>(null)
   const [nickNameResult, setNickNameResult] = useState<string | null>(null)
-  useEffect(() => {
-    const getUserNickName = async () => {
-      const nickName = await getNickname()
-      setNickName(nickName.data)
-    }
-    getUserNickName()
-  }, [])
+  const { user } = useUser()
 
   useEffect(() => {
-    if (nickName !== null) {
-      if (nickName === writer) {
+    if (user?.data !== null) {
+      if (user?.data === writer) {
         setNickNameResult('myComment')
       } else {
-        if (Recordwriter === nickName) {
+        if (Recordwriter === user?.data) {
           setNickNameResult('myRecordOtherReply')
         } else {
           setNickNameResult('otherRecordOtherReply')
         }
       }
     }
-  }, [Recordwriter, writer, nickName])
+  }, [Recordwriter, writer, user])
 
   return (
     <div className="mt-3">
@@ -48,13 +41,15 @@ export default function ReplyItem({
         {imageUrl !== null && (
           <div className="relative my-2.5 aspect-square w-[130px] rounded-2xl">
             <img
-              className=" h-full w-full rounded-2xl"
+              className="aspect-square w-full rounded-2xl object-cover"
               src={imageUrl}
               alt="user-selected-record-image"
             />
           </div>
         )}
-        <p className="mt-1.5 text-xs font-normal text-grey-8">{content}</p>
+        <p className="mt-1.5 text-xs font-normal leading-normal text-grey-8">
+          {content}
+        </p>
       </div>
       <div>
         <div className="mt-2 flex w-full justify-between">

--- a/src/pages/DetailRecord/ReplyList.tsx
+++ b/src/pages/DetailRecord/ReplyList.tsx
@@ -36,11 +36,7 @@ export default function ReplyList({
   return (
     <section id="reply" className="px-6">
       <h2 className="text-lg font-semibold">댓글</h2>
-      {isLoading && (
-        <div className="flex w-full justify-center">
-          <Spinner size="small" />
-        </div>
-      )}
+
       {data?.pages.map((page) =>
         page.data.commentList.map((item: CommentData) => (
           <ReplyItem
@@ -55,6 +51,12 @@ export default function ReplyList({
             writer={item.writer}
           />
         ))
+      )}
+
+      {hasNextPage && (
+        <div className="flex w-full justify-center">
+          <Spinner size="small" />
+        </div>
       )}
       <div ref={ref} className="h-10 w-full " />
     </section>

--- a/src/pages/DetailRecord/getChipIconName.ts
+++ b/src/pages/DetailRecord/getChipIconName.ts
@@ -25,7 +25,7 @@ export const getChipIconName = (categoryName: string) => {
       return Depress
     case '공감이 필요해요':
       return Sympathy
-    case '내 편이 되어주세요':
+    case '내편이 되어주세요':
       return MySide
     default:
       return ''

--- a/src/pages/DetailRecord/getCreatedDate.ts
+++ b/src/pages/DetailRecord/getCreatedDate.ts
@@ -43,8 +43,11 @@ export const getCreatedDate = (createdAt: string) => {
   // 게시물 작성 일주일 이상 작성 날짜,시간 반환
   if (differenceTime > 24) {
     const date = new Intl.DateTimeFormat('ko-KR', {
-      dateStyle: 'medium',
-      timeStyle: 'short',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: 'numeric',
+      minute: 'numeric',
       hour12: false,
     }).format(createdTime)
     return date


### PR DESCRIPTION
## 작업 내용
- 레코드 추가 후 상세페이지에서 ‘내편이 되어주세요’ 칩 이미지 안나오는 에러 수정
- 레코드 상세페이지 날짜 1.7 → 01.07 폼
- 댓글 100자 제한 placeholder 문구 추가
- 댓글 로딩 구현
- 댓글 이미지 인풋창 초기화
- 이미지 삽입 시 1:1 비율 구현
- 레코드 내용 라인하이츠 / 댓글 라인하이츠 수정
- 내가 쓴 글 외의 수정 버튼 안나오게 변경

## 참고 이미지(선택)
- 없음

## 어떤 점을 리뷰 받고 싶으신가요?
- 없음