### PR TITLE
[FE-153] refactor: 바뀐 추억 레코드 API 재적용과 Swipe 버그 픽스

### DIFF
--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,5 +1,8 @@
 import { baseInstance } from './instance'
 
+const MEMORY_RECORD_SIZE = 7
+const MEMORY_COMMENT_SIZE = 5
+
 export const getCategory = () => {
   return baseInstance.get('/record/category')
 }
@@ -18,9 +21,11 @@ export const getRecord = async (recordId: string | undefined) => {
 }
 
 export const getMemoryRecord = (pageParam: number) => {
-  return baseInstance.get(`/record/memory-list`, {
+  return baseInstance.get(`/record/memory`, {
     params: {
-      pageNum: pageParam,
+      memoryRecordPage: pageParam,
+      memoryRecordSize: MEMORY_RECORD_SIZE,
+      sizeOfCommentPerRecord: MEMORY_COMMENT_SIZE,
     },
   })
 }

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,6 +1,7 @@
-import { MutableRefObject } from 'react'
+import { MutableRefObject, useState } from 'react'
 
 const useSwipe = (ref: MutableRefObject<HTMLElement>) => {
+  const [isDragging, setIsDragging] = useState(false)
   let pos = { top: 0, left: 0, x: 0, y: 0 }
 
   const handleMouseDown = (e: React.MouseEvent<HTMLElement>) => {
@@ -16,6 +17,8 @@ const useSwipe = (ref: MutableRefObject<HTMLElement>) => {
   }
 
   const handleMouseMove = (e: MouseEvent) => {
+    setIsDragging(true)
+
     const dx = e.clientX - pos.x
     const dy = e.clientY - pos.y
 
@@ -34,7 +37,7 @@ const useSwipe = (ref: MutableRefObject<HTMLElement>) => {
     ref.current.style.removeProperty('user-select')
   }
 
-  return { handleMouseDown }
+  return { handleMouseDown, isDragging, setIsDragging }
 }
 
 export default useSwipe

--- a/src/pages/MyRecord/MemoryRecord.tsx
+++ b/src/pages/MyRecord/MemoryRecord.tsx
@@ -45,7 +45,7 @@ export default function MemoryRecord() {
             title={memoryRecord.title}
             iconName={memoryRecord.iconName}
             iconColor={memoryRecord.iconColor}
-            commentList={memoryRecord.commentList}
+            memoryRecordComments={memoryRecord.memoryRecordComments}
           />
         ))
       )}

--- a/src/pages/MyRecord/MemoryRecordItem.tsx
+++ b/src/pages/MyRecord/MemoryRecordItem.tsx
@@ -68,7 +68,7 @@ export default function MemoryRecordItem({
             </div>
           ))}
         </div>
-        {memoryRecordComments.length > 0 && (
+        {memoryRecordComments.length > 4 && (
           <div
             className="ml-2 flex h-full flex-col items-center justify-center"
             onClick={() => navigate(`/record/${recordId}`)}

--- a/src/pages/MyRecord/MemoryRecordItem.tsx
+++ b/src/pages/MyRecord/MemoryRecordItem.tsx
@@ -11,7 +11,7 @@ export default function MemoryRecordItem({
   title,
   iconName,
   iconColor,
-  commentList,
+  memoryRecordComments,
 }: IMemoryRecord) {
   const dragRef = useRef<HTMLDivElement | null>(
     null
@@ -56,7 +56,7 @@ export default function MemoryRecordItem({
           </div>
         </div>
         <div className="flex gap-2">
-          {commentList.map(({ commentId, content }) => (
+          {memoryRecordComments.map(({ commentId, content }) => (
             <div
               key={commentId}
               className="h-[86px] w-40 rounded-2xl bg-grey-2 py-4 px-5"
@@ -68,7 +68,7 @@ export default function MemoryRecordItem({
             </div>
           ))}
         </div>
-        {commentList.length > 0 && (
+        {memoryRecordComments.length > 0 && (
           <div
             className="ml-2 flex h-full flex-col items-center justify-center"
             onClick={() => navigate(`/record/${recordId}`)}

--- a/src/pages/MyRecord/MemoryRecordItem.tsx
+++ b/src/pages/MyRecord/MemoryRecordItem.tsx
@@ -16,13 +16,16 @@ export default function MemoryRecordItem({
   const dragRef = useRef<HTMLDivElement | null>(
     null
   ) as React.MutableRefObject<HTMLDivElement>
-  const { handleMouseDown } = useSwipe(dragRef)
+  const { handleMouseDown, isDragging, setIsDragging } = useSwipe(dragRef)
   const navigate = useNavigate()
   const background_color = `bg-${iconColor}`
   const RecordIcon = recordIcons[`${iconName}`]
 
   const handleClickComment = (commentId: number) => {
-    if (dragRef) return
+    if (isDragging) {
+      setIsDragging(false)
+      return
+    }
 
     navigate(`/record/${recordId}?commentId=${commentId}`)
   }
@@ -81,3 +84,4 @@ export default function MemoryRecordItem({
     </div>
   )
 }
+// e: React.MouseEvent<HTMLDivElement, MouseEvent>,

--- a/src/react-query/hooks/useMemoryRecord.ts
+++ b/src/react-query/hooks/useMemoryRecord.ts
@@ -14,8 +14,8 @@ export const useMemoryRecord = () => {
     queryFn: async ({ pageParam = 0 }) => await getMemoryRecord(pageParam),
     getNextPageParam: (lastPage): number | null => {
       const { data, config } = lastPage
-      if (data.hasNextPage && !data.isLastPage) {
-        return config.params.pageNum + 1
+      if (data.totalPage > config.params.memoryRecordPage + 1) {
+        return config.params.memoryRecordPage + 1
       }
       return null
     },

--- a/src/types/recordData.ts
+++ b/src/types/recordData.ts
@@ -32,7 +32,7 @@ export interface IMemoryRecord {
   title: string
   iconName: string
   iconColor: string
-  commentList: IRecordMemoryComment[]
+  memoryRecordComments: IRecordMemoryComment[]
 }
 
 export interface IRecordMemoryComment {


### PR DESCRIPTION
## 작업 내용
- [fix: 수정된 memory API로 재적용](https://github.com/ItRecode/recodeIt-client/commit/5a4aae20557b2aac2f4bb1a8d12db1941bfb350d)
- [fix: 댓글 전체보기 4개 이상 있을 경우 넣기](https://github.com/ItRecode/recodeIt-client/commit/192ed0e10b8b59849c0eacb9357c4ea4c0fdcaae)
- [fix: 드래그 시 댓글 클릭 안되는 버그 픽스](https://github.com/ItRecode/recodeIt-client/commit/ebb05380e507da398fd1c5af806589d2b72b80d7)