### PR TITLE
[FE-156]fix: 수정 페이지 이동시 버그

### DIFF
--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -8,10 +8,10 @@ import AddRecordFile from './AddRecordFile'
 import AddRecordTitle from './AddRecordTitle'
 import { TEXT_DETAILS } from '@assets/constant/constant'
 import MainCategoryTap from '@components/MainCategoryTap'
-import AddRecordIcon, { IconType } from './AddRecordIcon'
+import AddRecordIcon from './AddRecordIcon'
 import Button from '@components/Button'
 import { useNavigate } from 'react-router-dom'
-import { formDataAtom } from '@store/atom'
+import { formDataAtom, recordTypeAtom } from '@store/atom'
 import { useRecoilState } from 'recoil'
 import { enrollRecord, modifyRecord } from '@apis/record'
 import Alert from '@components/Alert'
@@ -54,7 +54,6 @@ export type IsInputFocusType = {
 
 export default function AddRecord() {
   const { CELEBRATION } = TEXT_DETAILS
-  const [recordType, setRecordType] = useState<keyof IconType>(CELEBRATION)
   const [checkAllFilled, setCheckAllFilled] = useState<CheckAllType>({
     input: '',
     textArea: '',
@@ -69,6 +68,7 @@ export default function AddRecord() {
   const [isInputFocus, setIsInputFocus] = useState(false)
   const [isMobile, setIsMobile] = useState<boolean>(false)
   const [toDeleteFiles, setToDeleteFiles] = useState<string[]>([])
+  const [recordType, setRecordType] = useRecoilState(recordTypeAtom)
   const ID = LocalStorage.get('postId') as string
   const isModify = LocalStorage.get('modifyMode') === 'true'
   const { data, isLoading, isSuccess } = useQuery(

--- a/src/pages/AddRecord/AddRecordCategory.tsx
+++ b/src/pages/AddRecord/AddRecordCategory.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react'
 
 import { TEXT_DETAILS } from '@assets/constant/constant'
 import Chip from '@components/Chip'
-import { useRecoilState } from 'recoil'
-import { formDataAtom } from '@store/atom'
+import { useRecoilState, useRecoilValue } from 'recoil'
+import { formDataAtom, recordTypeAtom } from '@store/atom'
 import {
   Cake,
   Celebrate,
@@ -47,6 +47,7 @@ function AddRecordCategory({
 }) {
   const [categoryState, setCategoryState] = useState<CategoryType | null>(null)
   const [formData, setFormData] = useRecoilState(formDataAtom)
+  const recordType = useRecoilValue(recordTypeAtom)
   const CELEBRATES = 3
   const CONSOLATES = 7
   const { data } = useQuery(['getCategory'], getCategory, {
@@ -58,8 +59,7 @@ function AddRecordCategory({
 
   useEffect(() => {
     handleChooseCurrentCategory(currentRecordType === 'celebration' ? 3 : 7)
-    // }
-  }, [currentRecordType])
+  }, [recordType])
 
   useEffect(() => {
     if (isModify) {
@@ -68,7 +68,7 @@ function AddRecordCategory({
         if (madeData !== null) {
           const modifyData = {
             ...madeData,
-            [currentRecordType]: madeData[currentRecordType].map(
+            [recordType]: madeData[recordType].map(
               (category: CategorySource) => {
                 return {
                   ...category,
@@ -81,17 +81,18 @@ function AddRecordCategory({
           setFormData({
             ...formData,
             selectedCategory:
-              modifyData[currentRecordType][
-                currentRecordType === 'celebration'
+              modifyData[recordType][
+                recordType === 'celebration'
                   ? recordCategory - CELEBRATES
                   : recordCategory - CONSOLATES
-              ].id,
+              ]?.id,
           })
         }
       }
     } else {
       setCategoryState(makeCategoryData(data?.data))
     }
+    // }
   }, [data])
 
   const makeCategoryData = (data: CategoryDatas) => {

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,3 +1,5 @@
+import { TEXT_DETAILS } from '@assets/constant/constant'
+import { IconType } from '@pages/AddRecord/AddRecordIcon'
 import { atom } from 'recoil'
 
 export const formDataAtom = atom({
@@ -20,4 +22,9 @@ export const DetailPageInputMode = atom<{
     recordId: '',
     parentId: '',
   },
+})
+
+export const recordTypeAtom = atom<keyof IconType>({
+  key: 'recordType',
+  default: TEXT_DETAILS.CELEBRATION,
 })


### PR DESCRIPTION
## 작업 내용
-해당 배열의 길이를 넘어가는 인덱스 대입시 화면 터지는 버그 수정
-수정 페이지 이동시 카테고리 변경안되는 버그 수정
-너무 많은 리렌더링 이슈로 recordType recoil로 이관
## 참고 이미지(선택)
![화면 기록 2023-01-27 오후 12 19 58](https://user-images.githubusercontent.com/103626175/215003110-fbc72e90-a816-4981-b4c4-39678c820799.gif)

## 어떤 점을 리뷰 받고 싶으신가요?
기존 추가후 레코드 수정도 되고, 위로일떄도 카테고리 잘 반영되는거 위에 확인부탁드릴게요!
리코일로 이관한 이유 자세하게 궁금하면 저한테 질문주세요!