### PR TITLE
[FE-159] fix: 댓글 id값 없을 경우 스크롤 id값 초기화

### DIFF
--- a/src/pages/DetailRecord/ReplyList.tsx
+++ b/src/pages/DetailRecord/ReplyList.tsx
@@ -50,6 +50,8 @@ export default function ReplyList({
 
     if (commentIdInQuery) {
       setScrollCommentId(parseInt(commentIdInQuery, 10))
+    } else {
+      setScrollCommentId(null)
     }
   }, [])
 


### PR DESCRIPTION
## 작업 내용
- fix: 댓글 id값 없을 경우 스크롤 id값 초기화

## 참고 이미지(선택)

## 어떤 점을 리뷰 받고 싶으신가요?