### PR TITLE
[FE-160] feat: 비회원일 경우 원래 페이지로 리다이렉트

### DIFF
--- a/src/pages/DetailRecord/ReplyInput.tsx
+++ b/src/pages/DetailRecord/ReplyInput.tsx
@@ -18,6 +18,7 @@ import { useUser } from '@react-query/hooks/useUser'
 import { useRecoilValue, useResetRecoilState } from 'recoil'
 import { DetailPageInputMode } from '@store/atom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { LocalStorage } from '@utils/localStorage'
 
 export default function ReplyInput({
   setInputSectionHeight,
@@ -154,6 +155,12 @@ export default function ReplyInput({
     setIsAnonymousUser(true)
   }
 
+  const handleConfirmSignUp = () => {
+    LocalStorage.set('redirectUrl', `/record/${recordIdParams}`)
+    resetInputMode()
+    navigate('/login')
+  }
+
   useEffect(() => {
     if (inputMode.mode === 'nestedReply') {
       textRef.current?.focus()
@@ -243,10 +250,7 @@ export default function ReplyInput({
           confirmMessage="회원가입"
           onClose={() => setIsCheckedUser(false)}
           onCancel={handleCancelSingUp}
-          onConfirm={() => {
-            resetInputMode
-            navigate('/login')
-          }}
+          onConfirm={handleConfirmSignUp}
         />
       )}
     </form>

--- a/src/react-query/hooks/useAuth.ts
+++ b/src/react-query/hooks/useAuth.ts
@@ -1,20 +1,30 @@
 import { login, signUp } from '@apis/auth'
 import { UNAUTHORIZED_CODE } from '@assets/constant/constant'
 import { useMutation } from '@tanstack/react-query'
+import { LocalStorage } from '@utils/localStorage'
 import { AxiosError, AxiosResponse } from 'axios'
 import { useNavigate } from 'react-router-dom'
 import { IAuth, ISignUp } from 'types/auth'
 
 export const useAuth = () => {
   const navigate = useNavigate()
+  const redirectUrl = LocalStorage.get('redirectUrl') as string
+
+  const redirectPage = () => {
+    if (!redirectUrl) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    navigate(redirectUrl, { replace: true })
+    LocalStorage.remove('redirectUrl')
+  }
 
   const { mutate: oauthLogin } = useMutation(
     async ({ type, token }: IAuth) => await login({ type, token }),
     {
       onSuccess: () => {
-        navigate('/', {
-          replace: true,
-        })
+        redirectPage()
       },
       onError: (error: AxiosError) => {
         if (error.response?.status === UNAUTHORIZED_CODE) {
@@ -40,9 +50,7 @@ export const useAuth = () => {
       await signUp({ type, tempId, nickname }),
     {
       onSuccess: () => {
-        navigate('/', {
-          replace: true,
-        })
+        redirectPage()
       },
       onError: () => {
         navigate('/login')

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useUser } from '@react-query/hooks/useUser'
 import Alert from '@components/Alert'
 import Loading from '@components/Loading'
+import { LocalStorage } from '@utils/localStorage'
 interface RouteProps {
   children: React.ReactElement
   route?: string
@@ -11,6 +12,11 @@ interface RouteProps {
 const ProtectedRoute = ({ children, route }: RouteProps) => {
   const navigate = useNavigate()
   const { user, isLoading } = useUser()
+
+  const redirectPage = (url: string) => {
+    LocalStorage.set('redirectUrl', url)
+    navigate('/login')
+  }
 
   if (isLoading) {
     return <Loading />
@@ -32,7 +38,7 @@ const ProtectedRoute = ({ children, route }: RouteProps) => {
         confirmMessage="회원가입"
         onClose={() => navigate('/')}
         onCancel={() => navigate('/')}
-        onConfirm={() => navigate('/login')}
+        onConfirm={() => redirectPage('/record/add')}
       />
     )
   }
@@ -53,7 +59,7 @@ const ProtectedRoute = ({ children, route }: RouteProps) => {
         confirmMessage="회원가입"
         onClose={() => navigate('/')}
         onCancel={() => navigate('/')}
-        onConfirm={() => navigate('/login')}
+        onConfirm={() => redirectPage('/myrecord')}
       />
     )
   }


### PR DESCRIPTION
## 작업 내용
- 아래페이지에 적용
  - 마이레코드 페이지
  - 레코드 수정/추가 페이지
  - 비댓글일 경우 댓글 클릭 후 회원가입 시


## 어떤 점을 리뷰 받고 싶으신가요?
1. recoil로 전역 관리하려했으나 카카오/구글 회원가입 시 무조건 새로고침이 일어나게 됨
2. 따라서 LocalStorage로 관리
