### PR TITLE
[FE-165] feat: 회원가입 이모지 안들어가도록 구현

### DIFF
--- a/src/components/NavbarItem.tsx
+++ b/src/components/NavbarItem.tsx
@@ -69,7 +69,11 @@ export default function NavbarItem({
   return (
     <Link to={linkSrc} className={`${containerFormat} ${className}`}>
       {navbarIcon(linkSrc)}
-      <p className={`${textFormat} ${checkPathWithText(linkSrc)} w-max`}>
+      <p
+        className={`${textFormat} ${checkPathWithText(
+          linkSrc
+        )} w-max whitespace-nowrap`}
+      >
         {pageName}
       </p>
     </Link>

--- a/src/components/NavbarItem.tsx
+++ b/src/components/NavbarItem.tsx
@@ -69,7 +69,7 @@ export default function NavbarItem({
   return (
     <Link to={linkSrc} className={`${containerFormat} ${className}`}>
       {navbarIcon(linkSrc)}
-      <p className={`${textFormat} ${checkPathWithText(linkSrc)}`}>
+      <p className={`${textFormat} ${checkPathWithText(linkSrc)} w-max`}>
         {pageName}
       </p>
     </Link>

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -19,9 +19,9 @@ export default function SignUp() {
   const [isInputClicked, setIsInputClicked] = useState(false)
 
   useEffect(() => {
-    if (!location.state?.tempSessionId) {
-      navigate('/login')
-    }
+    // if (!location.state?.tempSessionId) {
+    //   navigate('/login')
+    // }
   }, [])
 
   useDebounce(
@@ -101,20 +101,24 @@ export default function SignUp() {
         <br />
         사용하시겠어요?
       </h1>
-      <Input
-        property={setPropertyWithIsCheckedNickname()}
-        name="nickname"
-        label="닉네임"
-        value={nickname}
-        maxLength={8}
-        placeholder={isInputClicked ? '' : `국문, 영문, 숫자 포함 2~8자`}
-        message={isCheckedNickname ? '사용 가능한 닉네임입니다.' : errorMessage}
-        onChange={(e) => setNickname(e.target.value)}
-        onRemove={handleRemoveNickname}
-        onFocus={() => setIsInputClicked(true)}
-        onBlur={() => setIsInputClicked(false)}
-        autoFocus={false}
-      />
+      <div className="h-[105px]">
+        <Input
+          property={setPropertyWithIsCheckedNickname()}
+          name="nickname"
+          label="닉네임"
+          value={nickname}
+          maxLength={8}
+          placeholder={isInputClicked ? '' : `국문, 영문, 숫자 포함 2~8자`}
+          message={
+            isCheckedNickname ? '사용 가능한 닉네임입니다.' : errorMessage
+          }
+          onChange={(e) => setNickname(e.target.value)}
+          onRemove={handleRemoveNickname}
+          onFocus={() => setIsInputClicked(true)}
+          onBlur={() => setIsInputClicked(false)}
+          autoFocus={false}
+        />
+      </div>
       <div className="mt-[104px]">
         <Button
           type="submit"

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -19,9 +19,9 @@ export default function SignUp() {
   const [isInputClicked, setIsInputClicked] = useState(false)
 
   useEffect(() => {
-    // if (!location.state?.tempSessionId) {
-    //   navigate('/login')
-    // }
+    if (!location.state?.tempSessionId) {
+      navigate('/login')
+    }
   }, [])
 
   useDebounce(

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -46,6 +46,8 @@ export default function SignUp() {
     const spacePattern = /\s/g
     const consonantAndVowelPattern = /[ㄱ-ㅎㅏ-ㅣ]/
     const specialPattern = /[`~!@#$%^&*()_|+\-=?;:'",.<>\\{}[\]\\/₩]/gim
+    const emojiPattern =
+      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
 
     if (nickname.length < NICKNAME_MIN_LENGTH) {
       setErrorMessage(`${NICKNAME_MIN_LENGTH}글자 이상 입력해주세요.`)
@@ -64,6 +66,11 @@ export default function SignUp() {
 
     if (nickname.match(consonantAndVowelPattern)) {
       setErrorMessage('자음이나 모음만은 사용할 수 없어요.')
+      return false
+    }
+
+    if (nickname.match(emojiPattern)) {
+      setErrorMessage('이모지는 사용할 수 없어요.')
       return false
     }
 


### PR DESCRIPTION
## 작업 내용
-  회원가입 이모지 안들어가도록 구현
- 네브바 탭 마이레코드 디자인 변경
- 레코드 입장 버튼 움직이지 않도록 고정

## 참고 이미지(선택)
- 네브바 탭 맥 OS가 아닌 화면에서 아래처럼 나온다고 해서 디자인 w-max 넣음
- 적용이 안될 수도 있습니다..ㅠㅠ
![image](https://user-images.githubusercontent.com/50071076/215305600-528c910d-174f-4526-8330-dbbdb173a499.png)

## 어떤 점을 리뷰 받고 싶으신가요?