### PR TITLE
[FE-173]feat: 수정모드일때 수정불가능한것들 회색처리

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -7,6 +7,7 @@ interface chipProps {
   message: string
   pointer?: boolean
   property?: 'default' | 'small'
+  isModify?: boolean
 }
 
 function Chip({
@@ -16,13 +17,18 @@ function Chip({
   type,
   pointer = true,
   property = 'default',
+  isModify,
 }: chipProps) {
   return (
     <button
       type={type}
       className={`flex items-center rounded-full
         ${pointer && 'cursor-pointer'}
-        ${active ? ' bg-primary-2 text-grey-1' : ' bg-grey-2 text-grey-4'}
+        ${
+          active
+            ? `${isModify ? 'bg-grey-7' : 'bg-primary-2'} text-grey-1`
+            : ' bg-grey-2 text-grey-4'
+        }
         ${property === 'default' ? 'px-4 py-3' : 'px-3 py-[9px]'}
       `}
     >

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -29,7 +29,7 @@ function Chip({
             ? `${isModify ? 'bg-grey-7' : 'bg-primary-2'} text-grey-1`
             : ' bg-grey-2 text-grey-4'
         }
-        ${property === 'default' ? 'px-4 py-3' : 'px-3 py-[9px]'}\
+        ${property === 'default' ? 'px-4 py-3' : 'px-3 py-[9px]'}
       `}
     >
       {icon && (

--- a/src/components/MainCategoryTap.tsx
+++ b/src/components/MainCategoryTap.tsx
@@ -5,12 +5,20 @@ import { TEXT_DETAILS } from '@assets/constant/constant'
 type MainCategory = {
   onSetRecordType: Dispatch<SetStateAction<'celebration' | 'consolation'>>
   currentRecordType: string
+  isModify: boolean
 }
-function MainCategoryTap({ onSetRecordType, currentRecordType }: MainCategory) {
+function MainCategoryTap({
+  onSetRecordType,
+  currentRecordType,
+  isModify,
+}: MainCategory) {
   const { CELEBRATION, CONSOLATION } = TEXT_DETAILS
 
+  console.log(isModify)
   const typeConfig = {
-    active: 'text-primary-2 border-b-2 border-current',
+    active: `${
+      isModify ? 'text-grey-7' : 'text-primary-2'
+    } border-b-2 border-current`,
     inactive: 'text-gray-600',
   }
 

--- a/src/components/MainCategoryTap.tsx
+++ b/src/components/MainCategoryTap.tsx
@@ -14,7 +14,6 @@ function MainCategoryTap({
 }: MainCategory) {
   const { CELEBRATION, CONSOLATION } = TEXT_DETAILS
 
-  console.log(isModify)
   const typeConfig = {
     active: `${
       isModify ? 'text-grey-7' : 'text-primary-2'

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -219,6 +219,7 @@ export default function AddRecord() {
             } sticky top-0 left-0 z-[5] bg-grey-1`}
           >
             <MainCategoryTap
+              isModify={isModify}
               currentRecordType={recordType}
               onSetRecordType={setRecordType}
             />

--- a/src/pages/AddRecord/AddRecordCategory.tsx
+++ b/src/pages/AddRecord/AddRecordCategory.tsx
@@ -192,6 +192,7 @@ function AddRecordCategory({
               onClick={() => handleChooseCurrentCategory(category.id)}
             >
               <Chip
+                isModify={isModify}
                 type="button"
                 active={category.choosed}
                 message={category.title}


### PR DESCRIPTION
## 작업 내용
-수정모드일때 탭 회색처리
-수정모드일때 카테고리 회색처리
## 참고 이미지(선택)
<img width="424" alt="image" src="https://user-images.githubusercontent.com/103626175/215425892-f3fb71e9-6676-47af-92d8-7f785dd95703.png">

## 어떤 점을 리뷰 받고 싶으신가요?