### PR TITLE
[FE-184] feat: 메인페이지 함께 축하해보세요 기능 구현

### DIFF
--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -67,3 +67,9 @@ export const getRecordByDate = ({
     },
   })
 }
+
+export const getRandomRecordData = async (recordCategoryId: 1 | 2) => {
+  return await baseInstance.get('/record/random', {
+    params: { recordCategoryId, size: 5 },
+  })
+}

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -5,6 +5,7 @@ const useSwipe = (ref: MutableRefObject<HTMLElement>) => {
   let pos = { top: 0, left: 0, x: 0, y: 0 }
 
   const handleMouseDown = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault()
     pos = {
       left: ref.current.scrollLeft,
       top: ref.current.scrollTop,
@@ -17,8 +18,9 @@ const useSwipe = (ref: MutableRefObject<HTMLElement>) => {
   }
 
   const handleMouseMove = (e: MouseEvent) => {
-    setIsDragging(true)
-
+    if (!isDragging) {
+      setIsDragging(true)
+    }
     const dx = e.clientX - pos.x
     const dy = e.clientY - pos.y
 
@@ -29,7 +31,11 @@ const useSwipe = (ref: MutableRefObject<HTMLElement>) => {
     ref.current.style.userSelect = 'none'
   }
 
-  const handleMouseUp = () => {
+  const handleMouseUp = (e: MouseEvent) => {
+    if (isDragging) {
+      e.stopPropagation()
+      setIsDragging(false)
+    }
     document.removeEventListener('mousemove', handleMouseMove)
     document.removeEventListener('mouseup', handleMouseUp)
 

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,14 +1,11 @@
-import React from 'react'
-import { ReactComponent as NotServiceIcon } from '@assets/umbrella_big.svg'
+import React, { useState } from 'react'
+import Together from './Together'
 
 export default function Main() {
+  const [categoryId, setCategoryId] = useState<1 | 2>(1)
   return (
-    <div className="flex h-full flex-col items-center justify-center px-5">
-      <NotServiceIcon className=" mb-10" />
-      <p className="mb-4 font-semibold text-grey-10">
-        아직 준비 중인 서비스예요
-      </p>
-      <p className="mb-10 text-xs font-medium">서비스가 완성되면 만나요.</p>
+    <div className="h-full w-full">
+      <Together categoryId={categoryId} setCategoryId={setCategoryId} />
     </div>
   )
 }

--- a/src/pages/Main/TogethderSlider.tsx
+++ b/src/pages/Main/TogethderSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { IRandomRecordData } from 'types/recordData'
 import recordIcons from '@assets/record_icons'
 import { useNavigate } from 'react-router-dom'
@@ -6,8 +6,10 @@ import useSwipe from '@hooks/useSwipe'
 
 export default function TogethderSlider({
   randomRecordData,
+  categoryId,
 }: {
   randomRecordData: IRandomRecordData[] | null
+  categoryId: 1 | 2
 }) {
   const navigate = useNavigate()
 
@@ -25,6 +27,9 @@ export default function TogethderSlider({
     navigate(`/record/${recordId}`)
   }
 
+  useEffect(() => {
+    dragRef.current.scrollLeft = 0
+  }, [categoryId])
   return (
     <div
       className="relative ml-6 flex h-full flex-nowrap overflow-x-hidden"

--- a/src/pages/Main/TogethderSlider.tsx
+++ b/src/pages/Main/TogethderSlider.tsx
@@ -1,0 +1,62 @@
+import React, { useRef } from 'react'
+import { IRandomRecordData } from 'types/recordData'
+import recordIcons from '@assets/record_icons'
+import { useNavigate } from 'react-router-dom'
+import useSwipe from '@hooks/useSwipe'
+
+export default function TogethderSlider({
+  randomRecordData,
+}: {
+  randomRecordData: IRandomRecordData[] | null
+}) {
+  const navigate = useNavigate()
+
+  const dragRef = useRef<HTMLDivElement | null>(
+    null
+  ) as React.MutableRefObject<HTMLDivElement>
+
+  const { handleMouseDown, isDragging, setIsDragging } = useSwipe(dragRef)
+
+  const handleClickRecord = (recordId: number) => {
+    if (isDragging) {
+      setIsDragging(false)
+      return
+    }
+    navigate(`/record/${recordId}`)
+  }
+
+  return (
+    <div
+      className="relative ml-6 flex h-full flex-nowrap overflow-x-hidden"
+      ref={dragRef}
+      onMouseDownCapture={(e) => {
+        handleMouseDown(e)
+      }}
+    >
+      {randomRecordData !== null &&
+        randomRecordData.map((item) => {
+          const colorName = `bg-${item.colorName}`
+          const RecordIcon = recordIcons[`${item.iconName}`]
+          return (
+            <div
+              key={item.recordId}
+              className={`mr-1.5 h-full w-[164px] shrink-0 rounded-2xl ${colorName} flex items-center justify-center`}
+            >
+              <div
+                className="flex cursor-pointer flex-col items-center justify-center hover:scale-110"
+                onClick={() => handleClickRecord(item.recordId)}
+              >
+                <RecordIcon width={100} height={100} />
+                <p className="mt-4 text-sm font-semibold leading-none text-grey-10">
+                  {item.title}
+                </p>
+                <p className="mt-2.5 text-xs leading-none">
+                  댓글 {item.commentCount}개
+                </p>
+              </div>
+            </div>
+          )
+        })}
+    </div>
+  )
+}

--- a/src/pages/Main/Together.tsx
+++ b/src/pages/Main/Together.tsx
@@ -25,7 +25,9 @@ export default function Together({
     () => getRandomRecordData(categoryId),
     {
       retry: false,
+      refetchOnMount: false,
       refetchOnWindowFocus: false,
+      staleTime: Infinity,
     }
   )
 
@@ -61,7 +63,10 @@ export default function Together({
         {isLoading ? (
           <Spinner size="large" />
         ) : (
-          <TogethderSlider randomRecordData={randomRecordData} />
+          <TogethderSlider
+            randomRecordData={randomRecordData}
+            categoryId={categoryId}
+          />
         )}
       </section>
     </div>

--- a/src/pages/Main/Together.tsx
+++ b/src/pages/Main/Together.tsx
@@ -1,0 +1,69 @@
+import { getRandomRecordData } from '@apis/record'
+import Spinner from '@components/Spinner'
+import { useQuery } from '@tanstack/react-query'
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { IRandomRecordData } from 'types/recordData'
+import TogethderSlider from './TogethderSlider'
+import TogetherTab from './TogetherTab'
+
+export default function Together({
+  categoryId,
+  setCategoryId,
+}: {
+  categoryId: 1 | 2
+  setCategoryId: Dispatch<SetStateAction<1 | 2>>
+}) {
+  const navigate = useNavigate()
+
+  const [randomRecordData, setRandomRecordData] = useState<
+    IRandomRecordData[] | null
+  >(null)
+
+  const { data, isLoading, isSuccess } = useQuery(
+    ['randomRecordData', categoryId],
+    () => getRandomRecordData(categoryId),
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+    }
+  )
+
+  useEffect(() => {
+    if (isSuccess) {
+      setRandomRecordData(data.data)
+    }
+  }, [data, isSuccess])
+
+  return (
+    <div className="h-[50px] w-full">
+      <section id="tab">
+        <TogetherTab categoryId={categoryId} setCategoryId={setCategoryId} />
+      </section>
+      <section
+        id="title"
+        className="mt-10 mb-6 flex w-full justify-between px-6"
+      >
+        <p className="text-[24px] font-semibold leading-none">
+          함께 {categoryId === 1 ? '축하' : '위로'}해보세요!
+        </p>
+        <button
+          className="cursor-pointer bg-transparent text-grey-6"
+          onClick={() => navigate('/rank')}
+        >
+          전체보기
+        </button>
+      </section>
+      <section
+        id="slider"
+        className="flex h-[200px] items-center justify-center "
+      >
+        {isLoading ? (
+          <Spinner size="large" />
+        ) : (
+          <TogethderSlider randomRecordData={randomRecordData} />
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/pages/Main/TogetherTab.tsx
+++ b/src/pages/Main/TogetherTab.tsx
@@ -1,0 +1,45 @@
+import React, { Dispatch, SetStateAction } from 'react'
+
+export default function TogetherTab({
+  categoryId,
+  setCategoryId,
+}: {
+  categoryId: number
+  setCategoryId: Dispatch<SetStateAction<1 | 2>>
+}) {
+  return (
+    <>
+      <div className="flex h-full w-full">
+        <button
+          className="flex h-full w-1/2 border-collapse cursor-pointer items-center justify-center bg-transparent p-0"
+          onClick={() => setCategoryId(1)}
+        >
+          <p
+            className={`h-full w-fit border-collapse text-lg font-semibold leading-[50px] ${
+              categoryId === 1
+                ? 'border-b-2 border-solid border-b-primary-2 text-primary-2'
+                : 'text-grey-6'
+            }`}
+          >
+            축하 레코드
+          </p>
+        </button>
+        <button
+          className="flex h-full w-1/2 cursor-pointer items-center justify-center bg-transparent p-0"
+          onClick={() => setCategoryId(2)}
+        >
+          <p
+            className={`h-full w-fit text-lg font-semibold leading-[50px] ${
+              categoryId === 2
+                ? 'border-b-2 border-solid border-b-primary-2 text-primary-2'
+                : 'text-grey-6'
+            }`}
+          >
+            위로 레코드
+          </p>
+        </button>
+      </div>
+      <hr className="m-0 h-[1px] border-0 bg-grey-3" />
+    </>
+  )
+}

--- a/src/types/recordData.ts
+++ b/src/types/recordData.ts
@@ -51,3 +51,9 @@ export interface IMyRecordRequestParam {
   page: number
   size: number
 }
+
+export interface IRandomRecordData
+  extends Omit<IMemoryRecord, 'memoryRecordComments' | 'iconColor'> {
+  commentCount: number
+  colorName: string
+}


### PR DESCRIPTION
## 작업 내용
- 메인페이지 함께 축하해보세요 기능 구현
- swipe hook 약간 수정
- 탭 변경시 스크롤 초기화
- stale: Infinity 값을 주어 탭 변경해도 기존 아이템 유지되도록 구현함
- 스크롤 영역 전체가 cursor:pointer 로 지정되어 있어 클릭시 링크이동되는 영역 scale 1.1 로 구현했음

## 참고 이미지(선택)
https://user-images.githubusercontent.com/88193063/216765363-b3279f9d-7eab-4f77-bbe5-5aa2d8bfda23.mov

## 어떤 점을 리뷰 받고 싶으신가요?
- 링크 영역 scale 1.1 로 구현한거 괜찮은지?