### PR TITLE
[FE-189] fix: 페이지 이동 시 스크롤 Top으로 이동 안되던 버그 픽스

### DIFF
--- a/src/components/ScrollTop.tsx
+++ b/src/components/ScrollTop.tsx
@@ -1,0 +1,12 @@
+import React, { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function ScrollTop({ children }: { children: React.ReactNode }) {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return <>{children}</>
+}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -14,11 +14,16 @@ import NotService from '@pages/NotService/NotService'
 import OauthLogin from '@pages/Login/[type]'
 import SignUp from '@pages/SignUp/SignUp'
 import NotRecord from '@pages/NotRecord/NotRecord'
+import ScrollTop from '@components/ScrollTop'
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <NavBar />,
+    element: (
+      <ScrollTop>
+        <NavBar />
+      </ScrollTop>
+    ),
     children: [
       { index: true, element: <Main /> },
       { path: 'rank', element: <Rank /> },
@@ -56,7 +61,9 @@ const router = createBrowserRouter([
     path: '/record/add',
     element: (
       <ProtectedRoute route={'/record/add'}>
-        <AddRecord />
+        <ScrollTop>
+          <AddRecord />
+        </ScrollTop>
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
## 작업 내용
- fix: 페이지 이동 시 스크롤 Top으로 이동 안되던 버그 픽스
- NavBar에 있는 4개의 페이지와 레코드 추가 페이지에만 적용하였습니다

## 참고 이미지(선택)
![Feb-05-2023 18-03-04](https://user-images.githubusercontent.com/50071076/216810453-4e68d39a-aff2-4d03-a8f8-3d3aa495e5f0.gif)

## 어떤 점을 리뷰 받고 싶으신가요?