### PR TITLE
[FE-213]fix: 레코드 추가페이지 버그 픽스

### DIFF
--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -4,6 +4,7 @@ import { parentCategoryID } from 'types/category'
 import { getChipIconName } from '@pages/DetailRecord/getChipIconName'
 import Chip from './Chip'
 import useSwipe from '@hooks/useSwipe'
+import { CELEBRATION_ID, CONSOLATION_ID } from '@assets/constant/constant'
 
 export default function Category({
   slider,
@@ -26,11 +27,15 @@ export default function Category({
   const { handleMouseDown, isDragging, setIsDragging } = useSwipe(dragRef)
 
   useEffect(() => {
-    setChoosedCategoryId(0)
+    if (slider) setChoosedCategoryId(0)
+    if (!slider) {
+      if (parentCategoryId === CELEBRATION_ID) setChoosedCategoryId(3)
+      if (parentCategoryId === CONSOLATION_ID) setChoosedCategoryId(7)
+    }
   }, [parentCategoryId])
 
   const handleClickChip = (id?: number) => {
-    if (isDragging) {
+    if (slider && isDragging) {
       setIsDragging(false)
       return
     }

--- a/src/pages/AddRecord/AddRecord.tsx
+++ b/src/pages/AddRecord/AddRecord.tsx
@@ -104,7 +104,33 @@ export default function AddRecord() {
   }, [parentCategoryId])
 
   useEffect(() => {
+    window.addEventListener('beforeunload', () => LocalStorage.clear())
+    return () => {
+      resetFormDataAtom()
+      window.removeEventListener('beforeunload', () => LocalStorage.clear())
+    }
+  }, [])
+
+  useEffect(() => {
     if (recordData !== undefined) {
+      const categoryName = recordData.categoryName
+      if (categoryName) {
+        if (
+          categoryName === '축하해주세요' ||
+          categoryName === '기념일이에요' ||
+          categoryName === '연애중이에요' ||
+          categoryName === '행복해요'
+        ) {
+          setParentCategoryId(1)
+        } else if (
+          categoryName === '위로해주세요' ||
+          categoryName === '공감이 필요해요' ||
+          categoryName === '내편이 되어주세요' ||
+          categoryName === '우울해요'
+        ) {
+          setParentCategoryId(2)
+        }
+      }
       setIsInputsHasValue({
         input: recordData.title,
         textArea: recordData.content,
@@ -232,6 +258,7 @@ export default function AddRecord() {
             />
             <AddRecordTitle isModify={isModify} title={'레코드 제목'} />
             <AddRecordInput
+              modifyTitle={recordData?.title}
               recordTitle={recordTitle}
               setRecordTitle={setRecordTitle}
               isInputsHasValue={isInputsHasValue}
@@ -242,6 +269,7 @@ export default function AddRecord() {
             />
             <AddRecordTitle title={'레코드 설명'} />
             <AddRecordTextArea
+              modifyTitle={recordData?.content}
               recordContent={recordContent}
               setRecordContent={setRecordContent}
               isInputsHasValue={isInputsHasValue}
@@ -277,11 +305,17 @@ export default function AddRecord() {
               <Button
                 property={'solid'}
                 disabled={
-                  !(isInputsHasValue.input && isInputsHasValue.textArea) ||
-                  isLoadingWhileSubmit
+                  isModify
+                    ? false
+                    : !(recordTitle.length > 0 && recordContent.length > 0) ||
+                      isLoadingWhileSubmit
                 }
                 type="submit"
-                active={isInputsHasValue.input && isInputsHasValue.textArea}
+                active={
+                  isModify
+                    ? true
+                    : recordTitle.length > 0 && recordContent.length > 0
+                }
                 loading={isLoadingWhileSubmit}
               >
                 {isModify ? '수정하기' : '레코드 추가하기'}

--- a/src/pages/AddRecord/AddRecordCategory.tsx
+++ b/src/pages/AddRecord/AddRecordCategory.tsx
@@ -14,7 +14,7 @@ function AddRecordCategory({
   isModify: boolean
 }) {
   const [formData, setFormData] = useRecoilState(formDataAtom)
-  const [choosedCategoryId, setChoosedCategoryId] = useState(0)
+  const [choosedCategoryId, setChoosedCategoryId] = useState(3)
 
   useEffect(() => {
     setFormData({
@@ -34,15 +34,13 @@ function AddRecordCategory({
         isModify && 'pointer-events-none'
       } mt-6 mb-10 flex flex-wrap gap-x-2 gap-y-4`}
     >
-      {recordCategory && (
-        <Category
-          isModify={isModify}
-          slider={false}
-          parentCategoryId={parentCategoryId}
-          choosedCategoryId={choosedCategoryId}
-          setChoosedCategoryId={setChoosedCategoryId}
-        />
-      )}
+      <Category
+        isModify={isModify}
+        slider={false}
+        parentCategoryId={parentCategoryId}
+        choosedCategoryId={recordCategory ? recordCategory : choosedCategoryId}
+        setChoosedCategoryId={setChoosedCategoryId}
+      />
     </div>
   )
 }

--- a/src/pages/AddRecord/AddRecordInput.tsx
+++ b/src/pages/AddRecord/AddRecordInput.tsx
@@ -11,6 +11,7 @@ interface Props {
   setRecordTitle: Dispatch<SetStateAction<string>>
   parentCategoryId: parentCategoryID
   isModify?: boolean
+  modifyTitle: string
 }
 
 function AddRecordInput({
@@ -21,6 +22,7 @@ function AddRecordInput({
   setRecordTitle,
   parentCategoryId,
   isModify,
+  modifyTitle,
 }: Props) {
   const [isFocus, setIsFocus] = useState(false)
   const PLACEHOLDER_MESSAGE =
@@ -68,7 +70,7 @@ function AddRecordInput({
         placeholder={PLACEHOLDER_MESSAGE}
         onChange={(e) => handleChange(e)}
         type="text"
-        value={recordTitle}
+        value={modifyTitle ? modifyTitle : recordTitle}
       />
       <span className=" text-xs text-grey-4">{`${recordTitle.length}/${INPUT_DETAILS.MAX_INPUT_TYPING}`}</span>
     </div>

--- a/src/pages/AddRecord/AddRecordTextArea.tsx
+++ b/src/pages/AddRecord/AddRecordTextArea.tsx
@@ -10,6 +10,7 @@ type userProps = {
   setIsInputsHasValue: Dispatch<SetStateAction<IsInputsHasValueType>>
   isInputsHasValue: IsInputsHasValueType
   setIsInputFocus: Dispatch<SetStateAction<boolean>>
+  modifyTitle: string
 }
 
 function AddRecordTextArea({
@@ -19,6 +20,7 @@ function AddRecordTextArea({
   setIsInputFocus,
   recordContent,
   setRecordContent,
+  modifyTitle,
 }: userProps) {
   const PLACEHOLDER_MESSAGE = {
     celebration: 'ex) 오늘은 나의 생일이에요! 모두 축하해주세요!',
@@ -26,9 +28,8 @@ function AddRecordTextArea({
   }
 
   useEffect(() => {
-    setRecordContent('')
     setRecordContent(
-      recordContent
+      modifyTitle
         ? recordContent.replaceAll(/(<br>|<br\/>|<br \/>)/g, '\r\n')
         : ''
     )


### PR DESCRIPTION
## 작업 내용
-레코드 추가 접근시 카테고리 안보임
-화면 나갔을떄 수정모드 안지워짐
-수정모드 접근시 제목이나 카테고리 안먹힘
-레코드 추가에서 탭 바꾸면 textArea 초기화안됨
-추가하기(수정하기)버튼 제대로 안먹힘

## 참고 이미지(선택)
![화면 기록 2023-02-10 오후 12 25 36](https://user-images.githubusercontent.com/103626175/217993342-0c40a4ce-7888-4bd2-bbf0-af02abe71995.gif)
![화면 기록 2023-02-10 오후 12 28 04](https://user-images.githubusercontent.com/103626175/217993403-34e91016-ea43-4872-a4be-609650e0e502.gif)
![화면 기록 2023-02-10 오후 12 29 09](https://user-images.githubusercontent.com/103626175/217993543-cda38422-39d7-45dc-9568-19da7c78b87f.gif)

## 어떤 점을 리뷰 받고 싶으신가요?
자유롭게 리뷰 부탁드려요!!!