### PR TITLE
[FE-201] feat: 검색 페이지 API 연동과 myRecord 타입과 api 리팩토링

### DIFF
--- a/src/apis/myRecord.ts
+++ b/src/apis/myRecord.ts
@@ -2,9 +2,11 @@ import { AxiosResponse } from 'axios'
 import { baseInstance } from './instance'
 import {
   IMemoryRecordList,
+  IMyRecordByDateList,
+  IMyRecordByKeywordList,
+  IMyRecordByKeywordRequestParam,
   IMyRecordRequestParam,
-  IRecordByDateList,
-} from 'types/recordData'
+} from 'types/myRecord'
 
 const MEMORY_RECORD_SIZE = 7
 const MEMORY_COMMENT_SIZE = 5
@@ -25,7 +27,7 @@ export const getRecordByDate = ({
   date,
   page,
   size,
-}: IMyRecordRequestParam): Promise<AxiosResponse<IRecordByDateList>> => {
+}: IMyRecordRequestParam): Promise<AxiosResponse<IMyRecordByDateList>> => {
   return baseInstance.get(`/record`, {
     params: {
       date,
@@ -35,8 +37,14 @@ export const getRecordByDate = ({
   })
 }
 
-export const getSearchRecord = ({ keyword, page, size }:) => {
-  return baseInstance.get(`/record`, {
+export const getSearchRecord = ({
+  keyword,
+  page,
+  size,
+}: IMyRecordByKeywordRequestParam): Promise<
+  AxiosResponse<IMyRecordByKeywordList>
+> => {
+  return baseInstance.get(`/record/search`, {
     params: {
       searchKeyword: keyword,
       page,

--- a/src/apis/myRecord.ts
+++ b/src/apis/myRecord.ts
@@ -4,12 +4,12 @@ import {
   IMemoryRecordList,
   IMyRecordByDateList,
   IMyRecordByKeywordList,
-  IMyRecordByKeywordRequestParam,
   IMyRecordRequestParam,
 } from 'types/myRecord'
 
 const MEMORY_RECORD_SIZE = 7
 const MEMORY_COMMENT_SIZE = 5
+const MY_RECORD_KEYWORD_SIZE = 10
 
 export const getMemoryRecord = (
   pageParam: number
@@ -37,18 +37,15 @@ export const getRecordByDate = ({
   })
 }
 
-export const getSearchRecord = ({
-  keyword,
-  page,
-  size,
-}: IMyRecordByKeywordRequestParam): Promise<
-  AxiosResponse<IMyRecordByKeywordList>
-> => {
+export const getRecordByKeyword = (
+  pageParam: number,
+  keyword: string
+): Promise<AxiosResponse<IMyRecordByKeywordList>> => {
   return baseInstance.get(`/record/search`, {
     params: {
       searchKeyword: keyword,
-      page,
-      size,
+      page: pageParam,
+      size: MY_RECORD_KEYWORD_SIZE,
     },
   })
 }

--- a/src/apis/myRecord.ts
+++ b/src/apis/myRecord.ts
@@ -1,0 +1,46 @@
+import { AxiosResponse } from 'axios'
+import { baseInstance } from './instance'
+import {
+  IMemoryRecordList,
+  IMyRecordRequestParam,
+  IRecordByDateList,
+} from 'types/recordData'
+
+const MEMORY_RECORD_SIZE = 7
+const MEMORY_COMMENT_SIZE = 5
+
+export const getMemoryRecord = (
+  pageParam: number
+): Promise<AxiosResponse<IMemoryRecordList>> => {
+  return baseInstance.get(`/record/memory`, {
+    params: {
+      memoryRecordPage: pageParam,
+      memoryRecordSize: MEMORY_RECORD_SIZE,
+      sizeOfCommentPerRecord: MEMORY_COMMENT_SIZE,
+    },
+  })
+}
+
+export const getRecordByDate = ({
+  date,
+  page,
+  size,
+}: IMyRecordRequestParam): Promise<AxiosResponse<IRecordByDateList>> => {
+  return baseInstance.get(`/record`, {
+    params: {
+      date,
+      page,
+      size,
+    },
+  })
+}
+
+export const getSearchRecord = ({ keyword, page, size }:) => {
+  return baseInstance.get(`/record`, {
+    params: {
+      searchKeyword: keyword,
+      page,
+      size,
+    },
+  })
+}

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,14 +1,5 @@
 import { parentCategoryID } from './../types/category'
-import { AxiosResponse } from 'axios'
-import {
-  IMemoryRecordList,
-  IMyRecordRequestParam,
-  IRecordByDateList,
-} from 'types/recordData'
 import { baseInstance } from './instance'
-
-const MEMORY_RECORD_SIZE = 7
-const MEMORY_COMMENT_SIZE = 5
 
 export const getCategory = async (categoryId?: parentCategoryID) => {
   return await baseInstance.get('/record/category', {
@@ -29,18 +20,6 @@ export const getRecord = async (recordId: string | undefined) => {
   }
 }
 
-export const getMemoryRecord = (
-  pageParam: number
-): Promise<AxiosResponse<IMemoryRecordList>> => {
-  return baseInstance.get(`/record/memory`, {
-    params: {
-      memoryRecordPage: pageParam,
-      memoryRecordSize: MEMORY_RECORD_SIZE,
-      sizeOfCommentPerRecord: MEMORY_COMMENT_SIZE,
-    },
-  })
-}
-
 export const deleteRecord = async (recordId: string | undefined) => {
   if (recordId) {
     const res = await baseInstance.delete(`/record/${recordId}`)
@@ -54,20 +33,6 @@ export const modifyRecord = async (
 ) => {
   return baseInstance.put(`/record/${recordId}`, data, {
     headers: { 'Content-Type': 'multipart/form-data' },
-  })
-}
-
-export const getRecordByDate = ({
-  date,
-  page,
-  size,
-}: IMyRecordRequestParam): Promise<AxiosResponse<IRecordByDateList>> => {
-  return baseInstance.get(`/record`, {
-    params: {
-      date,
-      page,
-      size,
-    },
   })
 }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,7 +9,7 @@ export default function NavBar() {
   return (
     <>
       <Outlet />
-      <nav className="fixed bottom-0 flex h-[60px] w-full max-w-[420px] justify-between rounded-t-xl border border-solid border-grey-3 bg-white px-3 pt-1.5">
+      <nav className="fixed bottom-0 z-20 flex h-[60px] w-full max-w-[420px] justify-between rounded-t-xl border border-solid border-grey-3 bg-white px-3 pt-1.5">
         <nav className="left-3 flex">
           <NavbarItem pageName="홈" linkSrc="/" className="mr-5" />
           <NavbarItem pageName="모아보기" linkSrc="/rank" />

--- a/src/pages/MyRecord/Common/MemoryRecordCard.tsx
+++ b/src/pages/MyRecord/Common/MemoryRecordCard.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { IMemoryRecord } from 'types/recordData'
+import { IMemoryRecord } from 'types/myRecord'
 
 import useSwipe from '@hooks/useSwipe'
 import recordIcons from '@assets/record_icons'

--- a/src/pages/MyRecord/Common/MyRecordCard.tsx
+++ b/src/pages/MyRecord/Common/MyRecordCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import { IRecordByDate } from 'types/recordData'
+import { IMyRecord } from 'types/myRecord'
 import { getChipIconName } from '@pages/DetailRecord/getChipIconName'
 import { getFormattedDate } from '@utils/getFormattedDate'
 import Chip from '@components/Chip'
@@ -14,7 +14,7 @@ export default function MyRecordCard({
   iconName,
   colorName,
   createdAt,
-}: IRecordByDate) {
+}: IMyRecord) {
   const navigate = useNavigate()
   const background_color = `bg-${colorName}`
   const RecordIcon = recordIcons[`${iconName}`]

--- a/src/pages/MyRecord/Common/SearchInput.tsx
+++ b/src/pages/MyRecord/Common/SearchInput.tsx
@@ -19,6 +19,7 @@ export default function SearchInput({
         className="w-full rounded-[10px] bg-grey-2 py-[10px] pl-[38px] text-[14px] font-medium outline-none placeholder:text-grey-5"
         id="search-record-input"
         placeholder="레코드 제목을 입력하세요"
+        autoComplete="off"
         onChange={(e) => setKeyword(e.target.value)}
         onKeyUp={onKeyUp}
         {...props}

--- a/src/pages/MyRecord/Common/SearchInput.tsx
+++ b/src/pages/MyRecord/Common/SearchInput.tsx
@@ -8,9 +8,9 @@ interface SearchInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 export default function SearchInput({
-  value,
   onKeyUp,
   setKeyword,
+  ...props
 }: SearchInputProps) {
   return (
     <div className="relative flex w-full items-center">
@@ -18,10 +18,10 @@ export default function SearchInput({
       <input
         className="w-full rounded-[10px] bg-grey-2 py-[10px] pl-[38px] text-[14px] font-medium outline-none placeholder:text-grey-5"
         id="search-record-input"
-        value={value}
         placeholder="레코드 제목을 입력하세요"
         onChange={(e) => setKeyword(e.target.value)}
         onKeyUp={onKeyUp}
+        {...props}
       />
       <CloseIcon
         className="absolute right-[10px] cursor-pointer"

--- a/src/pages/MyRecord/MemoryRecord.tsx
+++ b/src/pages/MyRecord/MemoryRecord.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IMemoryRecord } from 'types/recordData'
+import { IMemoryRecord } from 'types/myRecord'
 import { useMemoryRecord } from '@react-query/hooks/useMemoryRecord'
 import { ReactComponent as Gift } from '@assets/record_icons/gift.svg'
 import { ReactComponent as ArrowDown } from '@assets/myRecordIcon/arrow_down.svg'

--- a/src/pages/MyRecord/MyRecord.tsx
+++ b/src/pages/MyRecord/MyRecord.tsx
@@ -34,7 +34,11 @@ export default function MyRecord() {
           id="search-bar"
           className="sticky top-0 left-0 bg-grey-1 py-4 px-6"
         >
-          <SearchInput onKeyUp={handleSearch} setKeyword={setKeyword} />
+          <SearchInput
+            value={keyword}
+            onKeyUp={handleSearch}
+            setKeyword={setKeyword}
+          />
         </section>
         <section id="my-today-record">
           <div className="mt-3 px-6">

--- a/src/pages/MyRecord/MyRecord.tsx
+++ b/src/pages/MyRecord/MyRecord.tsx
@@ -1,21 +1,25 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useSetRecoilState } from 'recoil'
 import { ReactComponent as CalendarIcon } from '@assets/myRecordIcon/calendar.svg'
 import { useMyRecordByDate } from '@react-query/hooks/useMyRecordByDate'
 import TodayRecord from './TodayRecord'
 import MemoryRecord from './MemoryRecord'
 import SearchInput from './Common/SearchInput'
 import Calendar from './Calendar/Calendar'
+import { searchedKeyword } from '@store/myRecordAtom'
 
 export default function MyRecord() {
   const navigate = useNavigate()
   const { isLoading, monthYear } = useMyRecordByDate()
   const [isOpenCalendar, setIsOpenCalendar] = useState(false)
   const [keyword, setKeyword] = useState('')
+  const setSearchedKeyword = useSetRecoilState(searchedKeyword)
 
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && keyword.length > 0) {
-      navigate('/myrecord/search', { state: keyword })
+      navigate('/myrecord/search')
+      setSearchedKeyword({ keyword })
     }
   }
 

--- a/src/pages/MyRecord/MyRecord.tsx
+++ b/src/pages/MyRecord/MyRecord.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ReactComponent as CalendarIcon } from '@assets/myRecordIcon/calendar.svg'
-import { useRecordByDate } from '@react-query/hooks/useRecordByDate'
+import { useMyRecordByDate } from '@react-query/hooks/useMyRecordByDate'
 import TodayRecord from './TodayRecord'
 import MemoryRecord from './MemoryRecord'
 import SearchInput from './Common/SearchInput'
@@ -9,7 +9,7 @@ import Calendar from './Calendar/Calendar'
 
 export default function MyRecord() {
   const navigate = useNavigate()
-  const { isLoading, monthYear } = useRecordByDate()
+  const { isLoading, monthYear } = useMyRecordByDate()
   const [isOpenCalendar, setIsOpenCalendar] = useState(false)
   const [keyword, setKeyword] = useState('')
 

--- a/src/pages/MyRecord/Search/SearchRecord.tsx
+++ b/src/pages/MyRecord/Search/SearchRecord.tsx
@@ -23,13 +23,6 @@ export default function SearchRecord() {
     fetchNextPage,
   } = useMyRecordByKeyword(keywordInStore)
 
-  const scrollEndRef = useIntersect(async (entry, observer) => {
-    observer.unobserve(entry.target)
-    if (hasNextPage && !isLoading) {
-      fetchNextPage()
-    }
-  })
-
   useDebounce(
     () => {
       if (keyword.length > 0) {
@@ -42,6 +35,13 @@ export default function SearchRecord() {
     300,
     [keyword]
   )
+
+  const scrollEndRef = useIntersect(async (entry, observer) => {
+    observer.unobserve(entry.target)
+    if (hasNextPage && !isLoading) {
+      fetchNextPage()
+    }
+  })
 
   return (
     <>

--- a/src/pages/MyRecord/Search/SearchRecord.tsx
+++ b/src/pages/MyRecord/Search/SearchRecord.tsx
@@ -7,6 +7,8 @@ import SearchInput from '../Common/SearchInput'
 import MyRecordCard from '../Common/MyRecordCard'
 import useDebounce from '@hooks/useDebounce'
 
+const KEYWORD_MAX_LENGTH = 12
+
 export default function SearchRecord() {
   const { keyword: keywordInStore } = useRecoilValue(searchedKeyword)
   const resetSearchedKeyword = useResetRecoilState(searchedKeyword)
@@ -40,6 +42,7 @@ export default function SearchRecord() {
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           setKeyword={setKeyword}
+          maxLength={KEYWORD_MAX_LENGTH}
         />
       </section>
       <section id="my-today-record">

--- a/src/pages/MyRecord/Search/SearchRecord.tsx
+++ b/src/pages/MyRecord/Search/SearchRecord.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
+import { useMyRecordByKeyword } from '@react-query/hooks/useMyRecordByKeyword'
+import { searchedKeyword } from '@store/myRecordAtom'
 import BackButton from '@components/BackButton'
 import SearchInput from '../Common/SearchInput'
 import MyRecordCard from '../Common/MyRecordCard'
 import useDebounce from '@hooks/useDebounce'
-import { useMyRecordByKeyword } from '@react-query/hooks/useMyRecordByKeyword'
 
 export default function SearchRecord() {
-  const { state } = useLocation() // 전역에 저장해놓기 => 검색어 없으면 메인으로 돌리기..?
-  const [keyword, setKeyword] = useState(state || '')
-  const { myRecordByKeyword, setKeywordWithQuery } = useMyRecordByKeyword(state)
+  const { keyword: keywordInStore } = useRecoilValue(searchedKeyword)
+  const [keyword, setKeyword] = useState(keywordInStore || '')
+  const { myRecordByKeyword, setKeywordWithQuery } =
+    useMyRecordByKeyword(keywordInStore)
 
   useDebounce(
     () => {
@@ -26,7 +28,10 @@ export default function SearchRecord() {
       <section id="route-backIcon-button" className="ml-[18px] mt-4">
         <BackButton />
       </section>
-      <section id="search-bar" className="mt-2 bg-grey-1 py-4 px-6">
+      <section
+        id="search-bar"
+        className="sticky top-0 left-0 mt-2 bg-grey-1 py-4 px-6"
+      >
         <SearchInput
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}

--- a/src/pages/MyRecord/Search/SearchRecord.tsx
+++ b/src/pages/MyRecord/Search/SearchRecord.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useRecoilValue } from 'recoil'
+import { useRecoilValue, useResetRecoilState } from 'recoil'
 import { useMyRecordByKeyword } from '@react-query/hooks/useMyRecordByKeyword'
 import { searchedKeyword } from '@store/myRecordAtom'
 import BackButton from '@components/BackButton'
@@ -9,6 +9,7 @@ import useDebounce from '@hooks/useDebounce'
 
 export default function SearchRecord() {
   const { keyword: keywordInStore } = useRecoilValue(searchedKeyword)
+  const resetSearchedKeyword = useResetRecoilState(searchedKeyword)
   const [keyword, setKeyword] = useState(keywordInStore || '')
   const { myRecordByKeyword, setKeywordWithQuery } =
     useMyRecordByKeyword(keywordInStore)
@@ -17,6 +18,9 @@ export default function SearchRecord() {
     () => {
       if (keyword.length > 0) {
         setKeywordWithQuery(keyword)
+      } else {
+        setKeywordWithQuery('')
+        resetSearchedKeyword
       }
     },
     300,

--- a/src/pages/MyRecord/Search/SearchRecord.tsx
+++ b/src/pages/MyRecord/Search/SearchRecord.tsx
@@ -3,19 +3,23 @@ import { useLocation } from 'react-router-dom'
 import BackButton from '@components/BackButton'
 import SearchInput from '../Common/SearchInput'
 import MyRecordCard from '../Common/MyRecordCard'
+import useDebounce from '@hooks/useDebounce'
+import { useMyRecordByKeyword } from '@react-query/hooks/useMyRecordByKeyword'
 
 export default function SearchRecord() {
-  const { state } = useLocation()
+  const { state } = useLocation() // 전역에 저장해놓기 => 검색어 없으면 메인으로 돌리기..?
   const [keyword, setKeyword] = useState(state || '')
-  const record = {
-    categoryName: '축하해주세요',
-    recordId: 276,
-    title: 'ㅎㅇㅎ',
-    iconName: 'gift',
-    colorName: 'icon-yellow',
-    createdAt: '2023-02-11T14:22:21.853545',
-    commentCount: 0,
-  }
+  const { myRecordByKeyword, setKeywordWithQuery } = useMyRecordByKeyword(state)
+
+  useDebounce(
+    () => {
+      if (keyword.length > 0) {
+        setKeywordWithQuery(keyword)
+      }
+    },
+    300,
+    [keyword]
+  )
 
   return (
     <>
@@ -35,15 +39,21 @@ export default function SearchRecord() {
         </div>
       </section>
       <section id="search-result-records" className="mt-4 mb-10 w-full px-6">
-        <MyRecordCard
-          recordId={record.recordId}
-          title={record.title}
-          categoryName={record.categoryName}
-          commentCount={record.commentCount}
-          iconName={record.iconName}
-          colorName={record.colorName}
-          createdAt={record.createdAt}
-        />
+        {myRecordByKeyword?.pages.map((page) =>
+          page.data.recordBySearchDtos.map((record) => (
+            <div className="mt-6" key={record.recordId}>
+              <MyRecordCard
+                recordId={record.recordId}
+                title={record.title}
+                categoryName={record.categoryName}
+                commentCount={record.commentCount}
+                iconName={record.iconName}
+                colorName={record.colorName}
+                createdAt={record.createdAt}
+              />
+            </div>
+          ))
+        )}
       </section>
     </>
   )

--- a/src/pages/MyRecord/TodayRecord.tsx
+++ b/src/pages/MyRecord/TodayRecord.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useRecordByDate } from '@react-query/hooks/useRecordByDate'
+import { useMyRecordByDate } from '@react-query/hooks/useMyRecordByDate'
 import MyRecordCard from './Common/MyRecordCard'
 
 export default function TodayRecord() {
   const navigate = useNavigate()
-  const { todayRecord } = useRecordByDate()
+  const { todayRecord } = useMyRecordByDate()
 
   if (!todayRecord) {
     return (

--- a/src/react-query/hooks/useMemoryRecord.ts
+++ b/src/react-query/hooks/useMemoryRecord.ts
@@ -1,6 +1,6 @@
 import { QUERY_KEYS } from '@react-query/queryKeys'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { getMemoryRecord } from '@apis/record'
+import { getMemoryRecord } from '@apis/myRecord'
 import { useState } from 'react'
 
 export const useMemoryRecord = () => {

--- a/src/react-query/hooks/useMyRecordByDate.ts
+++ b/src/react-query/hooks/useMyRecordByDate.ts
@@ -5,7 +5,7 @@ import { getFormattedDate } from '@utils/getFormattedDate'
 import { getMonthYearDetail } from '@pages/MyRecord/Calendar/getCalendarDetail'
 import { useState } from 'react'
 
-export const useRecordByDate = () => {
+export const useMyRecordByDate = () => {
   const [todayRecordId, setTodayRecordId] = useState<number | null>(null)
   const today = new Date()
   const currentMonthYear = getMonthYearDetail(new Date(today))

--- a/src/react-query/hooks/useMyRecordByKeyword.ts
+++ b/src/react-query/hooks/useMyRecordByKeyword.ts
@@ -1,0 +1,37 @@
+import { getRecordByKeyword } from '@apis/myRecord'
+import { QUERY_KEYS } from '@react-query/queryKeys'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+export const useMyRecordByKeyword = (stateKeyword: string) => {
+  const [keywordWithQuery, setKeywordWithQuery] = useState(stateKeyword || '')
+
+  const {
+    data: myRecordByKeyword = null,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: [QUERY_KEYS.searchRecord, keywordWithQuery],
+    queryFn: async ({ pageParam = 0 }) =>
+      await getRecordByKeyword(pageParam, keywordWithQuery),
+    getNextPageParam: (lastPage): number | null => {
+      const { data, config } = lastPage
+      if (data.totalPage > config.params.page + 1) {
+        return config.params.page + 1
+      }
+      return null
+    },
+    retry: false,
+  })
+
+  return {
+    setKeywordWithQuery,
+    myRecordByKeyword,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  }
+}

--- a/src/react-query/hooks/useMyRecordByKeyword.ts
+++ b/src/react-query/hooks/useMyRecordByKeyword.ts
@@ -11,7 +11,6 @@ export const useMyRecordByKeyword = (stateKeyword: string) => {
     isLoading,
     hasNextPage,
     fetchNextPage,
-    isFetchingNextPage,
   } = useInfiniteQuery({
     queryKey: [QUERY_KEYS.searchRecord, keywordWithQuery],
     queryFn: async ({ pageParam = 0 }) =>
@@ -32,6 +31,5 @@ export const useMyRecordByKeyword = (stateKeyword: string) => {
     isLoading,
     hasNextPage,
     fetchNextPage,
-    isFetchingNextPage,
   }
 }

--- a/src/react-query/hooks/useRecordByDate.ts
+++ b/src/react-query/hooks/useRecordByDate.ts
@@ -1,6 +1,6 @@
 import { QUERY_KEYS } from '@react-query/queryKeys'
 import { useQuery } from '@tanstack/react-query'
-import { getRecordByDate } from '@apis/record'
+import { getRecordByDate } from '@apis/myRecord'
 import { getFormattedDate } from '@utils/getFormattedDate'
 import { getMonthYearDetail } from '@pages/MyRecord/Calendar/getCalendarDetail'
 import { useState } from 'react'

--- a/src/react-query/queryKeys.ts
+++ b/src/react-query/queryKeys.ts
@@ -3,4 +3,5 @@ export const QUERY_KEYS = {
   nickname: 'nickname',
   myRecord: 'myRecord',
   memoryRecord: 'memoryRecord',
+  searchRecord: 'searchRecord',
 }

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -43,12 +43,7 @@ const ProtectedRoute = ({ children, route }: RouteProps) => {
     )
   }
 
-  if (
-    !user &&
-    (route === '/myrecord' ||
-      route === '/myrecord/search' ||
-      route === 'myrecord/date')
-  ) {
+  if (!user && route?.indexOf('myrecord')) {
     return (
       <Alert
         visible={true}

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -43,7 +43,12 @@ const ProtectedRoute = ({ children, route }: RouteProps) => {
     )
   }
 
-  if (!user && route === '/myrecord') {
+  if (
+    !user &&
+    (route === '/myrecord' ||
+      route === '/myrecord/search' ||
+      route === 'myrecord/date')
+  ) {
     return (
       <Alert
         visible={true}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -31,11 +31,32 @@ const router = createBrowserRouter([
       { path: 'rank', element: <Rank /> },
       {
         path: 'myrecord',
-        element: (
-          <ProtectedRoute route={'/myrecord'}>
-            <MyRecord />
-          </ProtectedRoute>
-        ),
+        children: [
+          {
+            index: true,
+            element: (
+              <ProtectedRoute route={'/myrecord'}>
+                <MyRecord />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: 'search',
+            element: (
+              <ProtectedRoute route={'/myrecord/search'}>
+                <SearchRecord />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: 'date',
+            element: (
+              <ProtectedRoute route={'/myrecord/date'}>
+                <CalendarRecord />
+              </ProtectedRoute>
+            ),
+          },
+        ],
       },
       {
         path: 'setting',
@@ -76,8 +97,6 @@ const router = createBrowserRouter([
     path: '/notservice',
     element: <NotService />,
   },
-  { path: '/myrecord/search', element: <SearchRecord /> },
-  { path: '/myrecord/date', element: <CalendarRecord /> },
 ])
 
 export default router

--- a/src/store/myRecordAtom.ts
+++ b/src/store/myRecordAtom.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil'
+
+export const searchedKeyword = atom<{
+  keyword: string
+}>({
+  key: 'searchedKeyword',
+  default: {
+    keyword: '',
+  },
+})

--- a/src/types/myRecord.ts
+++ b/src/types/myRecord.ts
@@ -1,0 +1,44 @@
+import { RecordCategory } from './recordData'
+import { PaginationRequest } from './request'
+import { PaginationResponse } from './response'
+
+// 추억 레코드
+interface IRecordMemoryComment {
+  commentId: number
+  content: string
+}
+
+export interface IMemoryRecord extends RecordCategory {
+  memoryRecordComments: IRecordMemoryComment[]
+}
+
+export interface IMemoryRecordList extends PaginationResponse {
+  memoryRecordList: IMemoryRecord[]
+}
+
+// 마이 레코드
+export interface IMyRecord {
+  recordId: number
+  title: string
+  categoryName: string
+  commentCount: number
+  iconName: string
+  colorName: string
+  createdAt: string
+}
+
+export interface IMyRecordByDateList extends PaginationResponse {
+  recordByDateDtos: IMyRecord[]
+}
+
+export interface IMyRecordByKeywordList extends PaginationResponse {
+  recordBySearchDtos: IMyRecord[]
+}
+
+export interface IMyRecordRequestParam extends PaginationRequest {
+  date: string
+}
+
+export interface IMyRecordByKeywordRequestParam extends PaginationRequest {
+  keyword: string
+}

--- a/src/types/recordData.ts
+++ b/src/types/recordData.ts
@@ -1,3 +1,5 @@
+import { IMemoryRecord } from './myRecord'
+
 export interface IRecordDataType {
   recordId: number
   categoryId: number
@@ -11,21 +13,11 @@ export interface IRecordDataType {
   imageUrls: string[]
 }
 
-export interface IMemoryRecordList {
-  memoryRecordList: IMemoryRecord[]
-  totalCount: number
-  totalPage: number
-}
-
-interface RecordCategory {
+export interface RecordCategory {
   recordId: number
   title: string
   iconName: string
   iconColor: string
-}
-
-export interface IMemoryRecord extends RecordCategory {
-  memoryRecordComments: IRecordMemoryComment[]
 }
 
 export interface CategoryCard {
@@ -34,33 +26,6 @@ export interface CategoryCard {
   iconName: string
   recordId: number
   title: string
-}
-
-export interface IRecordMemoryComment {
-  commentId: number
-  content: string
-}
-
-export interface IRecordByDate {
-  recordId: number
-  title: string
-  categoryName: string
-  commentCount: number
-  iconName: string
-  colorName: string
-  createdAt: string
-}
-
-export interface IRecordByDateList {
-  recordByDateDtos: IRecordByDate[]
-  totalCount: number
-  totalPage: number
-}
-
-export interface IMyRecordRequestParam {
-  date: string
-  page: number
-  size: number
 }
 
 export interface IRandomRecordData

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,0 +1,4 @@
+export interface PaginationRequest {
+  page: number
+  size: number
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,0 +1,4 @@
+export interface PaginationResponse {
+  totalCount: number
+  totalPage: number
+}


### PR DESCRIPTION
## 작업 내용
- 마이 레코드 페이지 Api와 타입 분리
- `myrecord/search`와 /myrecord/calendar`에 ProtectedRoute적용
- 검색 페이지 레이아웃 재적용과 API 연결
- 검색 무한 스크롤 구현

## 참고 이미지(선택)
![검색페이지](https://user-images.githubusercontent.com/50071076/218269166-c214a5b6-e9f4-42cf-8b17-6a7fb5da09cd.gif)

## 어떤 점을 리뷰 받고 싶으신가요?
전체적으로 부탁드립니다
수정된 파일이 많지만 대부분 폴더구조와 이름 변경으로 인한 내용이 많습니다 :)