### PR TITLE
[FE-219] feat: 메인페이지 카테고리ID 유지 추가

### DIFF
--- a/src/pages/DetailRecord/DetailRecord.tsx
+++ b/src/pages/DetailRecord/DetailRecord.tsx
@@ -31,7 +31,7 @@ import {
   DetailPageInputMode,
   modifyComment,
   nestedReplyState,
-} from '@store/atom'
+} from '@store/detailPageAtom'
 
 export default function DetailRecord() {
   const [shareStatus, setShareStatus] = useState(false)

--- a/src/pages/DetailRecord/InputSnackBar.tsx
+++ b/src/pages/DetailRecord/InputSnackBar.tsx
@@ -1,7 +1,7 @@
-import { DetailPageInputMode } from '@store/atom'
 import React, { Dispatch, SetStateAction } from 'react'
 import { useRecoilValue, useResetRecoilState } from 'recoil'
 import { ReactComponent as CloseIcon } from '@assets/detail_page_icon/Close.svg'
+import { DetailPageInputMode } from '@store/detailPageAtom'
 
 interface Iprops {
   setText: Dispatch<SetStateAction<string>>

--- a/src/pages/DetailRecord/InputTextarea.tsx
+++ b/src/pages/DetailRecord/InputTextarea.tsx
@@ -1,7 +1,7 @@
 import { RECORD_DETAIL_INPUT_HEIGHT_WITHOUT_TEXTAREA } from '@assets/constant/constant'
 import Alert from '@components/Alert'
 import { useUser } from '@react-query/hooks/useUser'
-import { DetailPageInputMode } from '@store/atom'
+import { DetailPageInputMode } from '@store/detailPageAtom'
 import { LocalStorage } from '@utils/localStorage'
 import React, {
   Dispatch,

--- a/src/pages/DetailRecord/NestedReplyItem.tsx
+++ b/src/pages/DetailRecord/NestedReplyItem.tsx
@@ -1,7 +1,7 @@
 import { deleteReply } from '@apis/reply'
 import Alert from '@components/Alert'
 import { useUser } from '@react-query/hooks/useUser'
-import { DetailPageInputMode, modifyComment } from '@store/atom'
+import { DetailPageInputMode, modifyComment } from '@store/detailPageAtom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import React, { useState } from 'react'
 import { useSetRecoilState } from 'recoil'

--- a/src/pages/DetailRecord/ReplyInput.tsx
+++ b/src/pages/DetailRecord/ReplyInput.tsx
@@ -9,16 +9,16 @@ import {
 } from '@assets/constant/constant'
 import { createReply, updateComment } from '@apis/reply'
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
-import {
-  DetailPageInputMode,
-  modifyComment,
-  nestedReplyState,
-  scrollTarget,
-} from '@store/atom'
+import { scrollTarget } from '@store/atom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import InputSnackBar from './InputSnackBar'
 import ReplyInputAddImage from './InputAddImage'
 import InputTextarea from './InputTextarea'
+import {
+  DetailPageInputMode,
+  modifyComment,
+  nestedReplyState,
+} from '@store/detailPageAtom'
 
 export default function ReplyInput({
   setInputSectionHeight,

--- a/src/pages/DetailRecord/ReplyItem.tsx
+++ b/src/pages/DetailRecord/ReplyItem.tsx
@@ -1,11 +1,6 @@
 import { INPUT_MODE } from '@assets/constant/constant'
 import { useUser } from '@react-query/hooks/useUser'
-import {
-  DetailPageInputMode,
-  modifyComment,
-  nestedReplyState,
-  scrollTarget,
-} from '@store/atom'
+import { scrollTarget } from '@store/atom'
 import React, { useEffect, useRef, useState } from 'react'
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
 import { CommentData } from 'types/replyData'
@@ -16,6 +11,11 @@ import { ReactComponent as Arrow_Up_icon } from '@assets/detail_page_icon/arrow_
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { deleteReply, getReply } from '@apis/reply'
 import Alert from '@components/Alert'
+import {
+  DetailPageInputMode,
+  modifyComment,
+  nestedReplyState,
+} from '@store/detailPageAtom'
 
 export default function ReplyItem({
   content,

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,14 +1,16 @@
-import { CELEBRATION_ID } from '@assets/constant/constant'
 import ParentCategoryTab from '@components/ParrentCategoryTab'
-import React, { useState } from 'react'
+import { parentCategoryIdAtom } from '@store/mainPageAtom'
+import React from 'react'
+import { useRecoilState } from 'recoil'
 import { parentCategoryID } from 'types/category'
 import MixRecord from './MixRecord'
 import Ranking from './Ranking'
 import Together from './Together'
 
 export default function Main() {
-  const [parentCategoryId, setParentCategoryId] =
-    useState<parentCategoryID>(CELEBRATION_ID)
+  const [parentCategoryID, setParentCategoryID] =
+    useRecoilState<parentCategoryID>(parentCategoryIdAtom)
+
   return (
     <>
       <section id="mixRecord">
@@ -16,15 +18,15 @@ export default function Main() {
       </section>
       <section id="tab" className="pt-3.5">
         <ParentCategoryTab
-          parentCategoryId={parentCategoryId}
-          setParentCategoryId={setParentCategoryId}
+          parentCategoryId={parentCategoryID}
+          setParentCategoryId={setParentCategoryID}
         />
       </section>
       <section id="Together">
-        <Together parentCategoryId={parentCategoryId} />
+        <Together parentCategoryId={parentCategoryID} />
       </section>
       <section id="Ranking">
-        <Ranking parentCategoryId={parentCategoryId} />
+        <Ranking parentCategoryId={parentCategoryID} />
       </section>
       <div className="h-[150px] w-full" />
     </>

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -9,40 +9,6 @@ export const formDataAtom = atom({
   },
 })
 
-export const DetailPageInputMode = atom<{
-  mode: 'reply' | 'nestedReply' | 'update'
-  recordId: string | undefined
-  parentId: number | string
-}>({
-  key: 'DetailPageInputMode',
-  default: {
-    mode: 'reply',
-    recordId: '',
-    parentId: '',
-  },
-})
-
-export const nestedReplyState = atom({
-  key: 'nestedReplyState',
-  default: {
-    commentId: 0,
-    state: false,
-  },
-})
-
-export const modifyComment = atom<{
-  commentId: number
-  content: string
-  imageUrl: string
-}>({
-  key: 'modifyComment',
-  default: {
-    commentId: 0,
-    content: '',
-    imageUrl: '',
-  },
-})
-
 export const scrollTarget = atom<{
   scrollReset: boolean
   commentId: number | null

--- a/src/store/detailPageAtom.ts
+++ b/src/store/detailPageAtom.ts
@@ -1,0 +1,35 @@
+import { atom } from 'recoil'
+
+export const DetailPageInputMode = atom<{
+  mode: 'reply' | 'nestedReply' | 'update'
+  recordId: string | undefined
+  parentId: number | string
+}>({
+  key: 'DetailPageInputMode',
+  default: {
+    mode: 'reply',
+    recordId: '',
+    parentId: '',
+  },
+})
+
+export const nestedReplyState = atom({
+  key: 'nestedReplyState',
+  default: {
+    commentId: 0,
+    state: false,
+  },
+})
+
+export const modifyComment = atom<{
+  commentId: number
+  content: string
+  imageUrl: string
+}>({
+  key: 'modifyComment',
+  default: {
+    commentId: 0,
+    content: '',
+    imageUrl: '',
+  },
+})

--- a/src/store/mainPageAtom.ts
+++ b/src/store/mainPageAtom.ts
@@ -1,0 +1,8 @@
+import { CELEBRATION_ID } from '@assets/constant/constant'
+import { atom } from 'recoil'
+import { parentCategoryID } from 'types/category'
+
+export const parentCategoryIdAtom = atom<parentCategoryID>({
+  key: 'parentCategoryId',
+  default: CELEBRATION_ID,
+})


### PR DESCRIPTION
## 작업 내용
- 카테고리 ID 전역상태로 변경하여 ID 값 유지
- atom 정리

## 참고 이미지(선택)
- 없음

## 어떤 점을 리뷰 받고 싶으신가요?
- 없음