### PR TITLE
[FE-229] fix: 메인페이지 & 랭킹 QA 피드백 반영

### DIFF
--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -64,3 +64,7 @@ export const getRanking = async (
     },
   })
 }
+
+export const getTotalRecordCount = async () => {
+  return await baseInstance.get('/record/count')
+}

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -5,6 +5,8 @@ import { getChipIconName } from '@pages/DetailRecord/getChipIconName'
 import Chip from './Chip'
 import useSwipe from '@hooks/useSwipe'
 import { CELEBRATION_ID, CONSOLATION_ID } from '@assets/constant/constant'
+import { useRecoilValue } from 'recoil'
+import { checkFromDetailPage } from '@store/detailPageAtom'
 
 export default function Category({
   slider,
@@ -26,12 +28,20 @@ export default function Category({
   ) as React.MutableRefObject<HTMLDivElement>
   const { handleMouseDown, isDragging, setIsDragging } = useSwipe(dragRef)
 
+  const isFromDetailPage = useRecoilValue(checkFromDetailPage)
+
   useEffect(() => {
     if (slider) {
-      if (parentCategoryId === CELEBRATION_ID)
-        setChoosedCategoryId(CELEBRATION_ID)
-      if (parentCategoryId === CONSOLATION_ID)
-        setChoosedCategoryId(CONSOLATION_ID)
+      if (
+        choosedCategoryId !== CELEBRATION_ID &&
+        choosedCategoryId !== CONSOLATION_ID &&
+        !isFromDetailPage
+      ) {
+        if (parentCategoryId === CELEBRATION_ID)
+          setChoosedCategoryId(CELEBRATION_ID)
+        if (parentCategoryId === CONSOLATION_ID)
+          setChoosedCategoryId(CONSOLATION_ID)
+      }
       dragRef.current.scrollLeft = 0
     }
     if (!slider) {
@@ -51,6 +61,7 @@ export default function Category({
       setChoosedCategoryId(parentCategoryId)
     }
   }
+
   return (
     <div
       className={`flex pr-4 ${

--- a/src/components/RankingItem.tsx
+++ b/src/components/RankingItem.tsx
@@ -34,7 +34,10 @@ export default function RankingItem({
       : 'max-w-[35%]'
 
   return (
-    <div className="relative mb-5 flex h-12 w-full items-center justify-between px-6">
+    <div
+      className="relative mb-5 flex h-12 w-full cursor-pointer items-center justify-between px-6"
+      onClick={() => navigate(`/record/${recordId}`)}
+    >
       <div className="flex w-full items-center">
         <p className="w-[16px] text-center">{index}</p>
         <div
@@ -51,10 +54,7 @@ export default function RankingItem({
         </div>
       </div>
 
-      <button
-        className="absolute right-6 flex cursor-pointer items-center whitespace-nowrap bg-transparent p-0"
-        onClick={() => navigate(`/record/${recordId}`)}
-      >
+      <button className="absolute right-6 flex items-center whitespace-nowrap bg-transparent p-0">
         <p>함께 {parentCategoryId === CELEBRATION_ID ? '축하' : '위로'}하기</p>
         <Arrow className="ml-4" />
       </button>

--- a/src/components/RecordCard.tsx
+++ b/src/components/RecordCard.tsx
@@ -43,17 +43,8 @@ function RecordCard({
       onClick={() => handleClickRecord(recordId)}
     >
       <RecordIcon width={100} height={100} />
-      <div className="mt-4 text-sm font-semibold text-grey-10">
-        {title.length > 6 ? (
-          <>
-            <p>{title.substring(0, 6)}</p>
-            <p className="text-center">
-              {title.substring(6).replaceAll('(^\\p{Z}+|\\p{Z}+$)', '')}
-            </p>
-          </>
-        ) : (
-          title
-        )}
+      <div className="mt-4 w-full text-sm font-semibold text-grey-10">
+        <p className="w-full truncate px-5 text-center">{title}</p>
       </div>
       <p className="mt-2.5 text-xs leading-none">댓글 {commentCount}개</p>
     </div>

--- a/src/pages/Collect/Collect.tsx
+++ b/src/pages/Collect/Collect.tsx
@@ -5,12 +5,15 @@ import { ReactComponent as ScrollTop } from '@assets/collect_page_icon/scrollTop
 import CollectRanking from './CollectRanking'
 import PeriodModal from './PeriodModal'
 import { keyOfRankingPeriod } from '@assets/constant/ranking'
+import { useRecoilState } from 'recoil'
+import { rankingPeriodAtom } from '@store/collectPageAtom'
 
 export default function Collect() {
   const collectRef: React.RefObject<HTMLDivElement> = useRef(null)
   const [isScroll, setIsScroll] = useState(false)
 
-  const [rankingPeriod, setRankingPeriod] = useState<keyOfRankingPeriod>('DAY')
+  const [rankingPeriod, setRankingPeriod] =
+    useRecoilState<keyOfRankingPeriod>(rankingPeriodAtom)
   const [openModal, setOpenModal] = useState(false)
 
   const NAVBAR_HEIGHT = 60
@@ -77,6 +80,7 @@ export default function Collect() {
           <CollectRanking
             setOpenModal={setOpenModal}
             rankingPeriod={rankingPeriod}
+            setRankingPeriod={setRankingPeriod}
           />
         </section>
         <RecentRecord />

--- a/src/pages/Collect/RecentRecord.tsx
+++ b/src/pages/Collect/RecentRecord.tsx
@@ -50,7 +50,11 @@ function RecentRecord() {
   })
 
   if (isLoading) {
-    return <Spinner size="large" />
+    return (
+      <div className="flex w-full justify-center">
+        <Spinner size="large" />
+      </div>
+    )
   }
 
   const handleReset = () => {

--- a/src/pages/DetailRecord/DetailRecord.tsx
+++ b/src/pages/DetailRecord/DetailRecord.tsx
@@ -26,8 +26,9 @@ import { useUser } from '@react-query/hooks/useUser'
 import Alert from '@components/Alert'
 import { AxiosError } from 'axios'
 import { createBrowserHistory } from 'history'
-import { useResetRecoilState } from 'recoil'
+import { useResetRecoilState, useSetRecoilState } from 'recoil'
 import {
+  checkFromDetailPage,
   DetailPageInputMode,
   modifyComment,
   nestedReplyState,
@@ -121,13 +122,16 @@ export default function DetailRecord() {
   const resetInputMode = useResetRecoilState(DetailPageInputMode)
   const resetNestedReplyState = useResetRecoilState(nestedReplyState)
   const resetModifyComment = useResetRecoilState(modifyComment)
+  const fromDetailPage = useSetRecoilState(checkFromDetailPage)
 
   useEffect(() => {
+    fromDetailPage(true)
     const unlistenHistoryEvent = history.listen(({ action }) => {
       if (action === 'POP' || action === 'PUSH') {
         resetInputMode()
         resetNestedReplyState()
         resetModifyComment()
+        fromDetailPage(false)
       }
       return unlistenHistoryEvent
     })

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,21 +1,43 @@
 import ParentCategoryTab from '@components/ParrentCategoryTab'
 import { usePreviousUrlWithStorage } from '@react-query/hooks/usePreviousUrlWithStorage'
-import { parentCategoryIdAtom } from '@store/mainPageAtom'
-import React from 'react'
-import { useRecoilState } from 'recoil'
+import { parentCategoryIdAtomMainPage } from '@store/mainPageAtom'
+import React, { useEffect } from 'react'
+import { useRecoilState, useRecoilValue } from 'recoil'
 import { parentCategoryID } from 'types/category'
-import MixRecord from './MixRecord'
+// import MixRecord from './MixRecord'
 import Ranking from './Ranking'
 import Together from './Together'
+import { ReactComponent as HomeImg } from '@assets/home_img.svg'
+import { useNavigate } from 'react-router-dom'
+import { checkFromDetailPage } from '@store/detailPageAtom'
+import { CELEBRATION_ID } from '@assets/constant/constant'
 
 export default function Main() {
   const [parentCategoryID, setParentCategoryID] =
-    useRecoilState<parentCategoryID>(parentCategoryIdAtom)
+    useRecoilState<parentCategoryID>(parentCategoryIdAtomMainPage)
+
   usePreviousUrlWithStorage('sessionStorage')
+
+  const navigate = useNavigate()
+  const isFromDetailPage = useRecoilValue(checkFromDetailPage)
+
+  useEffect(() => {
+    if (!isFromDetailPage) {
+      setParentCategoryID(CELEBRATION_ID)
+    }
+  }, [])
+
   return (
     <>
       <section id="mixRecord">
-        <MixRecord />
+        {/* <MixRecord /> */}
+        <div className="w-full cursor-pointer p-0">
+          <HomeImg
+            width="100%"
+            height="100%"
+            onClick={() => navigate('/record/31')}
+          />
+        </div>
       </section>
       <section id="tab" className="pt-3.5">
         <ParentCategoryTab

--- a/src/pages/Main/Ranking.tsx
+++ b/src/pages/Main/Ranking.tsx
@@ -5,10 +5,11 @@ import { useNavigate } from 'react-router-dom'
 import Category from '@components/Category'
 import { useQuery } from '@tanstack/react-query'
 import { getRanking } from '@apis/record'
-import { CELEBRATION_ID } from '@assets/constant/constant'
 import { useEffect } from 'react'
 import { IRankingRecordData } from 'types/recordData'
 import RankingList from './RankingList'
+import { useRecoilState } from 'recoil'
+import { subCategoryIdAtomMainPage } from '@store/mainPageAtom'
 
 export default function Ranking({
   parentCategoryId,
@@ -17,10 +18,19 @@ export default function Ranking({
 }) {
   const navigate = useNavigate()
   const [rankingData, setRankingData] = useState<IRankingRecordData[]>()
-  const [choosedCategoryId, setChoosedCategoryId] = useState(CELEBRATION_ID)
+  const [choosedCategoryId, setChoosedCategoryId] = useRecoilState<number>(
+    subCategoryIdAtomMainPage
+  )
 
-  const { data, isSuccess } = useQuery(['ranking', choosedCategoryId], () =>
-    getRanking(choosedCategoryId, 'WEEK')
+  const { data, isSuccess } = useQuery(
+    ['ranking', choosedCategoryId],
+    () => getRanking(choosedCategoryId, 'WEEK'),
+    {
+      retry: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    }
   )
 
   useEffect(() => {
@@ -33,11 +43,13 @@ export default function Ranking({
     <div className="relative mt-[43px]">
       <section id="title" className="flex items-center justify-between px-6">
         <button
-          className="flex cursor-pointer items-center bg-transparent p-0"
+          className="flex h-6 cursor-pointer items-center bg-transparent p-0"
           onClick={() => navigate('/collect')}
         >
-          <p className="text-lg font-semibold">레코드 랭킹</p>
-          <Right_Arrow_icon className="mb-1" />
+          <p className="h-full pt-[4px] text-lg font-semibold leading-none">
+            레코드 랭킹
+          </p>
+          <Right_Arrow_icon />
         </button>
         <p className="text-xs text-grey-6">최근 일주일</p>
       </section>

--- a/src/store/collectPageAtom.ts
+++ b/src/store/collectPageAtom.ts
@@ -1,0 +1,19 @@
+import { keyOfRankingPeriod } from './../assets/constant/ranking'
+import { CELEBRATION_ID } from './../assets/constant/constant'
+import { parentCategoryID } from './../types/category'
+import { atom } from 'recoil'
+
+export const parentCategoryIdAtomColletPage = atom<parentCategoryID>({
+  key: 'parentCategoryIdCollectPage',
+  default: CELEBRATION_ID,
+})
+
+export const subCategoryIdAtomCollectPage = atom<number>({
+  key: 'subCategoryIdAtomCollectPage',
+  default: parentCategoryIdAtomColletPage,
+})
+
+export const rankingPeriodAtom = atom<keyOfRankingPeriod>({
+  key: 'rankingPeriodAtom',
+  default: 'DAY',
+})

--- a/src/store/detailPageAtom.ts
+++ b/src/store/detailPageAtom.ts
@@ -33,3 +33,8 @@ export const modifyComment = atom<{
     imageUrl: '',
   },
 })
+
+export const checkFromDetailPage = atom<boolean>({
+  key: 'fromDetailPage',
+  default: false,
+})

--- a/src/store/mainPageAtom.ts
+++ b/src/store/mainPageAtom.ts
@@ -2,7 +2,12 @@ import { CELEBRATION_ID } from '@assets/constant/constant'
 import { atom } from 'recoil'
 import { parentCategoryID } from 'types/category'
 
-export const parentCategoryIdAtom = atom<parentCategoryID>({
-  key: 'parentCategoryId',
+export const parentCategoryIdAtomMainPage = atom<parentCategoryID>({
+  key: 'parentCategoryIdMainPage',
   default: CELEBRATION_ID,
+})
+
+export const subCategoryIdAtomMainPage = atom<number>({
+  key: 'subCategoryIdAtomMainPage',
+  default: parentCategoryIdAtomMainPage,
 })


### PR DESCRIPTION
## 작업 내용
- 레코드 랭킹 옆에 버튼 디자인 조정
- 랭킹 아이템 전체 누르면 상세페이지 이동
- 믹스레코드 미모티콘 으로 다시 돌리기
- 레코드카드 두줄일때 디자인 반영
- 상세페이지에서 뒤로가기 해서 이동 시 카테고리 / 기간 설정 유지
- 모아보기 페이지 총 레코드 갯수 api 연결 

## 참고 이미지(선택)
- 없음

## 어떤 점을 리뷰 받고 싶으신가요?
- 없음