### PR TITLE
[FE-230] fix: 검색 input 포커스 해제 시 placeholder 초기화 버그 픽스

### DIFF
--- a/src/pages/MyRecord/Common/SearchInput.tsx
+++ b/src/pages/MyRecord/Common/SearchInput.tsx
@@ -27,6 +27,7 @@ export default function SearchInput({
         autoComplete="off"
         onChange={(e) => setKeyword(e.target.value)}
         onFocus={() => setIsClickedInput(true)}
+        onBlur={() => setIsClickedInput(false)}
         onKeyUp={onKeyUp}
         maxLength={RECORD_TITLE_MAX_LENGTH}
         {...props}


### PR DESCRIPTION
## 작업 내용
[FE-230] fix: 검색 input 포커스 해제 시 placeholder 초기화 버그 픽스
## 참고 이미지(선택)

## 어떤 점을 리뷰 받고 싶으신가요?

[FE-230]: https://recodeit.atlassian.net/browse/FE-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ