### PR TITLE
[FE-249] feat: 카테고리 스크롤 유지 추가

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useRef } from 'react'
-import { checkFromDetailPage } from '@store/detailPageAtom'
-import { useRecoilValue } from 'recoil'
 
 interface chipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset' | undefined

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
+import { checkFromDetailPage } from '@store/detailPageAtom'
+import { useRecoilValue } from 'recoil'
 
 interface chipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset' | undefined
@@ -20,8 +22,21 @@ function Chip({
   isModify,
   ...props
 }: chipProps) {
+  const scrollRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (active) {
+      scrollRef.current?.scrollIntoView({
+        behavior: 'auto',
+        block: 'nearest',
+        inline: 'center',
+      })
+    }
+  }, [])
+
   return (
     <button
+      ref={scrollRef}
       {...props}
       type={type}
       className={`flex shrink-0 items-center justify-between rounded-full

--- a/src/pages/Collect/CollectRanking.tsx
+++ b/src/pages/Collect/CollectRanking.tsx
@@ -70,8 +70,8 @@ export default function CollectRanking({
         setPlusBtnState(false)
       }
     }
-    if (rankingList?.length === 0) setPlusBtnState(false)
-  }, [rankingPeriod, choosedCategoryId, rankingState, rankingData, rankingList])
+    if (rankingData?.length === 0) setPlusBtnState(false)
+  }, [rankingPeriod, choosedCategoryId, rankingState, rankingData])
 
   useEffect(() => {
     if (!isFromDetailPage) {
@@ -84,7 +84,10 @@ export default function CollectRanking({
     <div className="mt-4 w-full">
       <div className="pl-[26px]">
         <p className="text-sm leading-none">
-          총 <span className="text-primary-2">{totalRecordCount?.data}개</span>{' '}
+          총{' '}
+          <span className="text-primary-2">
+            {totalRecordCount?.data.toLocaleString()} 개
+          </span>
           의 레코딧
         </p>
         <p className="mt-6 text-2xl font-semibold leading-none">

--- a/src/pages/Main/RankingList.tsx
+++ b/src/pages/Main/RankingList.tsx
@@ -31,6 +31,9 @@ export default function RankingList({
     }
   }, [rankingState, rankingData])
 
+  useEffect(() => {
+    if (rankingList?.length === 0) setPlusBtnState(false)
+  }, [rankingList])
   return (
     <div className="mt-8">
       {rankingList?.length !== 0 ? (


### PR DESCRIPTION
## 작업 내용
- 카테고리 스크롤 유지 기능 추가

## 참고 이미지(선택)
- 스크롤(좌우) 기억 추가

https://user-images.githubusercontent.com/88193063/220933582-3167cbd4-72b7-477d-a25d-a63299945f29.mov


- 최신 레코드에서 상세 페이지로 넘어갔다와도 카테고리에서 스크롤 걸림

https://user-images.githubusercontent.com/88193063/220933624-d26e46f9-ca33-4ff7-b3af-a3fcb7854c20.mov



## 어떤 점을 리뷰 받고 싶으신가요?
- 모아보기 페이지에서 최신 레코드의 스크롤탑 기능이랑 충돌하는데 어떻게 해야할까요?