### PR TITLE
fix: 설정 페이지 라우팅 변경

### DIFF
--- a/src/pages/Setting/Setting.tsx
+++ b/src/pages/Setting/Setting.tsx
@@ -25,10 +25,13 @@ export default function Setting() {
               </p>
               <p>안녕하세요</p>
             </div>
-            <SettingSection routeText="내 정보 수정" routeUrl="/modifyinfo" />
+            <SettingSection
+              routeText="내 정보 수정"
+              routeUrl="/setting/modifyinfo"
+            />
             <SettingSection
               routeText="내 댓글 관리"
-              routeUrl="/managecomment"
+              routeUrl="/setting/managecomment"
             />
           </section>
           <div className={`h-[15px] ${getPaddingIgnoreWidth()} bg-grey-2`} />
@@ -51,15 +54,21 @@ export default function Setting() {
             <Front />
           </div>
         )}
-        <SettingSection routeText="팀 소개" routeUrl="/teamintroduction" />
-        <SettingSection routeText="피드백 메일" routeUrl="/feedbackmail" />
+        <SettingSection
+          routeText="팀 소개"
+          routeUrl="/setting/teamintroduction"
+        />
+        <SettingSection
+          routeText="피드백 메일"
+          routeUrl="/setting/feedbackmail"
+        />
       </section>
       {user && (
         <div>
           <div className={`h-[15px] ${getPaddingIgnoreWidth()} bg-grey-2`} />
           <section>
             <SettingSection routeText="로그아웃" />
-            <SettingSection routeText="회원탈퇴" routeUrl="/withdraw" />
+            <SettingSection routeText="회원탈퇴" routeUrl="/setting/withdraw" />
           </section>
         </div>
       )}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -63,9 +63,19 @@ const router = createBrowserRouter([
           },
         ],
       },
+    ],
+  },
+  {
+    path: 'setting',
+    children: [
       {
-        path: 'setting',
-        element: <Setting />,
+        index: true,
+        element: (
+          <ScrollTop>
+            <NavBar />
+            <Setting />
+          </ScrollTop>
+        ),
       },
       {
         path: 'modifyinfo',
@@ -82,6 +92,18 @@ const router = createBrowserRouter([
             <ManageComment />
           </ProtectedRoute>
         ),
+      },
+      {
+        path: 'teamintroduction',
+        element: <TeamIntroduction />,
+      },
+      {
+        path: 'feedbackmail',
+        element: <FeedbackMail />,
+      },
+      {
+        path: 'withdraw',
+        element: <Withdraw />,
       },
     ],
   },
@@ -113,18 +135,6 @@ const router = createBrowserRouter([
   {
     path: '/notservice',
     element: <NotService />,
-  },
-  {
-    path: '/teamintroduction',
-    element: <TeamIntroduction />,
-  },
-  {
-    path: '/feedbackmail',
-    element: <FeedbackMail />,
-  },
-  {
-    path: '/withdraw',
-    element: <Withdraw />,
   },
 ])
 


### PR DESCRIPTION
## 작업 내용
- 설정 페이지 라우팅 변경
- 설정 페이지 하위 목록 페이지를 설정페이지의 children 으로 변경
- 설정 페이지에서만 navbar 가 쓰여서 공통 엘리먼트에서 navbar 삭제후 설정페이지에서만 쓰이도록 변경함

## 참고 이미지(선택)
- 없음

## 어떤 점을 리뷰 받고 싶으신가요?
- 없음