### PR TITLE
[FE-238] feat: 내 정보 수정(닉네임 수정) api 연동 및 페이지 레이아웃 구현

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -3,3 +3,7 @@ import { baseInstance } from './instance'
 export const getUserInfo = () => {
   return baseInstance.get(`/member/auth`)
 }
+
+export const updateUserInfo = (nickname: string) => {
+  return baseInstance.put(`/member`, { params: { nickname } })
+}

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -5,5 +5,5 @@ export const getUserInfo = () => {
 }
 
 export const updateUserInfo = (nickname: string) => {
-  return baseInstance.put(`/member`, { params: { nickname } })
+  return baseInstance.put(`/member`, { nickName: nickname })
 }

--- a/src/assets/constant/constant.ts
+++ b/src/assets/constant/constant.ts
@@ -38,3 +38,6 @@ export const INPUT_MODE = Object.freeze({
   REPLY: 'reply',
   NESTEDREPLY: 'nestedReply',
 })
+
+export const NICKNAME_MIN_LENGTH = 2
+export const NICKNAME_MAX_LENGTH = 8

--- a/src/pages/Setting/ModifyInfo/ModifyInfo.tsx
+++ b/src/pages/Setting/ModifyInfo/ModifyInfo.tsx
@@ -1,7 +1,116 @@
-import React from 'react'
+import React, { useRef, useState } from 'react'
+import { ReactComponent as CloseIcon } from '@assets/icon_closed.svg'
+import { updateUserInfo } from '@apis/user'
+import useDebounce from '@hooks/useDebounce'
+import BackButton from '@components/BackButton'
+import { useUser } from '@react-query/hooks/useUser'
+import { getIsValidateNickname } from '@utils/getIsValidateNickname'
+import { NICKNAME_MAX_LENGTH } from '@assets/constant/constant'
+import Button from '@components/Button'
+import { useCheckMobile } from '@hooks/useCheckMobile'
 
 function ModifyInfo() {
-  return <div>내정보수정인데용</div>
+  const { user } = useUser()
+  const { isMobile } = useCheckMobile()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [isCheckedNickname, setIsCheckedNickname] = useState(false)
+  const [nickname, setNickname] = useState(user?.data)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+
+  useDebounce(
+    async () => {
+      setErrorMessage('')
+      setIsCheckedNickname(false)
+      if (
+        nickname.length > 0 &&
+        getIsValidateNickname(nickname, setErrorMessage)
+      ) {
+        try {
+          // await updateUserInfo(nickname)
+          setIsCheckedNickname(true)
+        } catch (e) {
+          setErrorMessage('이미 사용중인 닉네임이에요.')
+          setIsCheckedNickname(false)
+        }
+      }
+    },
+    300,
+    [nickname]
+  )
+
+  return (
+    <div className="relative h-screen w-full">
+      <section id="route-backIcon-button" className="ml-[18px] mt-4">
+        <BackButton />
+      </section>
+      <section id="modify-info-nickname" className="relative mt-11 px-6">
+        <p className="font-medium">닉네임</p>
+        <div className="relative mt-[9px] flex w-full items-center">
+          <input
+            ref={inputRef}
+            id="modify-nickname-input"
+            value={nickname}
+            className={`w-full rounded-[8px] bg-grey-2 py-[17px] pl-[12px] text-[14px] font-medium placeholder:text-grey-5 focus:outline-none
+              ${
+                nickname.length === 0
+                  ? 'border-none'
+                  : isCheckedNickname
+                  ? 'border border-solid border-primary-2'
+                  : 'border border-sub-1 outline-primary-2'
+              }`}
+            autoComplete="off"
+            onChange={(e) => setNickname(e.target.value)}
+            maxLength={NICKNAME_MAX_LENGTH}
+            autoFocus
+          />
+          <CloseIcon
+            className="absolute right-[10px] cursor-pointer"
+            onClick={() => {
+              setNickname('')
+              inputRef.current?.focus()
+            }}
+          />
+        </div>
+        <p
+          className={`pt-3 text-sm ${
+            isCheckedNickname ? 'text-primary-2' : 'text-sub-1'
+          }`}
+        >
+          {isCheckedNickname ? '사용 가능한 닉네임이에요.' : errorMessage}
+        </p>
+      </section>
+      {isMobile && isKeyboardOpen ? (
+        <div className="fixed bottom-0 left-0 w-full">
+          <Button
+            type="submit"
+            property="solid"
+            active={isCheckedNickname}
+            // onClick={handleSignUp}
+            // loading={isLoading}
+            // disabled={isLoading}
+            onFocus={() => setIsKeyboardOpen(true)}
+            onBlur={() => setIsKeyboardOpen(false)}
+          >
+            수정 완료
+          </Button>
+        </div>
+      ) : (
+        <div className="relative mt-[104px] px-6">
+          <Button
+            type="submit"
+            property="solid"
+            active={isCheckedNickname}
+            // onClick={handleSignUp}
+            // loading={isLoading}
+            // disabled={isLoading}
+          >
+            수정 완료
+          </Button>
+        </div>
+      )}
+    </div>
+  )
 }
 
 export default ModifyInfo

--- a/src/pages/Setting/Setting.tsx
+++ b/src/pages/Setting/Setting.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 import SettingSection from './SettingSection'
 import { ReactComponent as Front } from '@assets/front_white.svg'
 import { useNavigate } from 'react-router-dom'
+import Loading from '@components/Loading'
 
 export default function Setting() {
-  const { user } = useUser()
+  const { user, isLoading } = useUser()
   const PADDING_VALUE = 24
 
   const navigate = useNavigate()
@@ -13,6 +14,11 @@ export default function Setting() {
   const getPaddingIgnoreWidth = () => {
     return `ml-[-${PADDING_VALUE}px] w-[calc(100%+${PADDING_VALUE * 2}px)]`
   }
+
+  if (isLoading) {
+    return <Loading />
+  }
+
   return (
     <div className="flex  h-full flex-col px-6 pt-10">
       {user !== null ? (

--- a/src/pages/Setting/Setting.tsx
+++ b/src/pages/Setting/Setting.tsx
@@ -28,6 +28,7 @@ export default function Setting() {
             <SettingSection
               routeText="내 정보 수정"
               routeUrl="/setting/modifyinfo"
+              state={{ nickname: user.data }}
             />
             <SettingSection
               routeText="내 댓글 관리"

--- a/src/pages/Setting/SettingSection.tsx
+++ b/src/pages/Setting/SettingSection.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 import { ReactComponent as Front } from '@assets/front.svg'
 import { useNavigate } from 'react-router-dom'
-
 interface SettingSectionProps {
   routeUrl?: string
   routeText: string
+  state?: Record<string, string>
 }
 
-function SettingSection({ routeUrl, routeText }: SettingSectionProps) {
+function SettingSection({ routeUrl, routeText, state }: SettingSectionProps) {
   const navigate = useNavigate()
 
   const handleClickSection = () => {
     if (routeUrl) {
-      navigate(routeUrl)
+      navigate(routeUrl, { state })
     }
   }
 

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -6,8 +6,8 @@ import Input from '@components/Input'
 import { useAuth } from '@react-query/hooks/useAuth'
 import { getIsDuplicatedNickname } from '@apis/auth'
 import useDebounce from '@hooks/useDebounce'
-
-const NICKNAME_MIN_LENGTH = 2
+import { NICKNAME_MAX_LENGTH } from '@assets/constant/constant'
+import { getIsValidateNickname } from '@utils/getIsValidateNickname'
 
 export default function SignUp() {
   const location = useLocation()
@@ -28,7 +28,10 @@ export default function SignUp() {
     async () => {
       setErrorMessage('')
       setIsCheckedNickname(false)
-      if (nickname.length > 0 && validateNickname(nickname)) {
+      if (
+        nickname.length > 0 &&
+        getIsValidateNickname(nickname, setErrorMessage)
+      ) {
         try {
           await getIsDuplicatedNickname(nickname)
           setIsCheckedNickname(true)
@@ -41,41 +44,6 @@ export default function SignUp() {
     300,
     [nickname]
   )
-
-  const validateNickname = (nickname: string) => {
-    const spacePattern = /\s/g
-    const consonantAndVowelPattern = /[ㄱ-ㅎㅏ-ㅣ]/
-    const specialPattern = /[`~!@#$%^&*()_|+\-=?;:'",.<>\\{}[\]\\/₩]/gim
-    const emojiPattern =
-      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
-
-    if (nickname.length < NICKNAME_MIN_LENGTH) {
-      setErrorMessage(`${NICKNAME_MIN_LENGTH}글자 이상 입력해주세요.`)
-      return false
-    }
-
-    if (nickname.match(spacePattern)) {
-      setErrorMessage('공백은 사용할 수 없어요.')
-      return false
-    }
-
-    if (nickname.match(specialPattern)) {
-      setErrorMessage('특수문자는 사용할 수 없어요.')
-      return false
-    }
-
-    if (nickname.match(consonantAndVowelPattern)) {
-      setErrorMessage('자음이나 모음만은 사용할 수 없어요.')
-      return false
-    }
-
-    if (nickname.match(emojiPattern)) {
-      setErrorMessage('이모지는 사용할 수 없어요.')
-      return false
-    }
-
-    return true
-  }
 
   const setPropertyWithIsCheckedNickname = () => {
     if (nickname.length < 1 && !isInputClicked) return 'default'
@@ -107,7 +75,7 @@ export default function SignUp() {
           name="nickname"
           label="닉네임"
           value={nickname}
-          maxLength={8}
+          maxLength={NICKNAME_MAX_LENGTH}
           placeholder={isInputClicked ? '' : `국문, 영문, 숫자 포함 2~8자`}
           message={
             isCheckedNickname ? '사용 가능한 닉네임입니다.' : errorMessage

--- a/src/utils/getIsValidateNickname.ts
+++ b/src/utils/getIsValidateNickname.ts
@@ -1,0 +1,40 @@
+import { NICKNAME_MIN_LENGTH } from '@assets/constant/constant'
+import { Dispatch, SetStateAction } from 'react'
+
+export const getIsValidateNickname = (
+  nickname: string,
+  setErrorMessage: Dispatch<SetStateAction<string>>
+) => {
+  const spacePattern = /\s/g
+  const consonantAndVowelPattern = /[ㄱ-ㅎㅏ-ㅣ]/
+  const specialPattern = /[`~!@#$%^&*()_|+\-=?;:'",.<>\\{}[\]\\/₩]/gim
+  const emojiPattern =
+    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
+
+  if (nickname.length < NICKNAME_MIN_LENGTH) {
+    setErrorMessage(`${NICKNAME_MIN_LENGTH}글자 이상 입력해주세요.`)
+    return false
+  }
+
+  if (nickname.match(spacePattern)) {
+    setErrorMessage('공백은 사용할 수 없어요.')
+    return false
+  }
+
+  if (nickname.match(specialPattern)) {
+    setErrorMessage('특수문자는 사용할 수 없어요.')
+    return false
+  }
+
+  if (nickname.match(consonantAndVowelPattern)) {
+    setErrorMessage('자음이나 모음만은 사용할 수 없어요.')
+    return false
+  }
+
+  if (nickname.match(emojiPattern)) {
+    setErrorMessage('이모지는 사용할 수 없어요.')
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## 작업 내용
- 닉네임 수정 api 연동
- 아직 피그마와 정책대로 완료하지는 못했습니다. 기본 기능 구현만 적용되어 있는 상태입니다!

## 참고 이미지(선택)
![닉네임수정](https://user-images.githubusercontent.com/50071076/221910026-efe90298-f36f-4955-a4ac-ef311d2619ed.gif)

## 어떤 점을 리뷰 받고 싶으신가요?
- 모두 부탁드려요