### PR TITLE
fix: 피드백 메일 버튼 하단 고정 height 680 이상에서만 적용

### DIFF
--- a/src/pages/Setting/FeedbackMail/FeedbackMail.tsx
+++ b/src/pages/Setting/FeedbackMail/FeedbackMail.tsx
@@ -133,8 +133,8 @@ function FeedbackMail() {
         </div>
         <div
           className={`${
-            window.innerHeight > 680 ? 'absolute' : 'my-10 block'
-          } bottom-10 w-full cursor-pointer px-6`}
+            window.innerHeight > 680 ? 'absolute bottom-10' : 'my-10 block'
+          } w-full cursor-pointer px-6`}
         >
           <Button
             property="solid"


### PR DESCRIPTION
## 작업 내용
- 피드백 메일 버튼 하단 고정 height 680 이상에서만 적용

## 참고 이미지(선택)
- 없음

## 어떤 점을 리뷰 받고 싶으신가요?
- 없음